### PR TITLE
Invalid vertx-ext-parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-ext-parent</artifactId>
-    <version>34</version>
+    <version>35</version>
   </parent>
 
   <artifactId>vertx-json-schema</artifactId>


### PR DESCRIPTION
Signed-off-by: Paul Gallagher <pgallagh@redhat.com>

Motivation:

Simple update for invalid version of parent

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
