### PR TITLE
More verbose ValidationException on anyOf

### DIFF
--- a/src/main/java/io/vertx/ext/json/schema/ValidationException.java
+++ b/src/main/java/io/vertx/ext/json/schema/ValidationException.java
@@ -4,6 +4,10 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.VertxException;
 import io.vertx.core.json.pointer.JsonPointer;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
  * This is the main class for every Validation flow related errors
  *
@@ -26,6 +30,10 @@ public class ValidationException extends VertxException {
     super(message, cause);
     this.keyword = keyword;
     this.input = input;
+  }
+
+  public static ValidationException createException(String message, String keyword, Object input, Collection<Throwable> causes) {
+    return createException(message + ". Multiple causes: " + formatExceptions(causes), keyword, input);
   }
 
   public static ValidationException createException(String message, String keyword, Object input, Throwable cause) {
@@ -90,5 +98,16 @@ public class ValidationException extends VertxException {
       ", schema=" + schema +
       ((scope != null) ? ", scope=" + scope.toURI() : "") +
       '}';
+  }
+
+  private static String formatExceptions(Collection<Throwable> throwables) {
+    if (throwables == null) {
+      return "[]";
+    }
+    return "[" + throwables
+      .stream()
+      .filter(Objects::nonNull)
+      .map(Throwable::getMessage)
+      .collect(Collectors.joining(", ")) + "]";
   }
 }

--- a/src/main/java/io/vertx/ext/json/schema/common/AnyOfValidatorFactory.java
+++ b/src/main/java/io/vertx/ext/json/schema/common/AnyOfValidatorFactory.java
@@ -5,8 +5,12 @@ import io.vertx.core.Future;
 import io.vertx.ext.json.schema.NoSyncValidationException;
 import io.vertx.ext.json.schema.ValidationException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.vertx.ext.json.schema.ValidationException.createException;
 
@@ -31,16 +35,24 @@ public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
-      ValidationException res = null;
+      List<Throwable> res = null;
       for (SchemaInternal s : this.schemas) {
         try {
           s.validateSync(context, in);
           return;
         } catch (ValidationException e) {
-          res = e;
+          if (res == null) {
+             res = new ArrayList<>();
+          }
+          res.add(e);
         }
       }
-      throw res;
+      throw createException(
+        "anyOf subschemas don't match",
+        "anyOf",
+        in,
+        res
+      );
     }
 
     @Override
@@ -48,10 +60,19 @@ public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
       if (isSync()) return validateSyncAsAsync(context, in);
       return CompositeFuture
         .any(Arrays.stream(this.schemas).map(s -> s.validateAsync(context, in)).collect(Collectors.toList()))
-        .compose(
-          res -> Future.succeededFuture(),
-          err -> Future.failedFuture(createException("anyOf subschemas don't match", "anyOf", in, err))
-        );
+        .compose(cf -> {
+          if (cf.succeeded()) {
+            return Future.succeededFuture();
+          } else {
+            return Future.failedFuture(
+              createException(
+                "anyOf subschemas don't match",
+                "anyOf",
+                in,
+                IntStream.range(0, cf.size()).mapToObj(cf::cause).filter(Objects::nonNull).collect(Collectors.toList()))
+            );
+          }
+        });
     }
 
   }

--- a/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
+++ b/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
@@ -140,6 +140,8 @@ public abstract class BaseIntegrationTest {
       else if (log.isDebugEnabled())
         log.debug(event.cause().toString());
 
+      event.cause().printStackTrace();
+
       if (skipSyncCheck(schema)) {
         context.completeNow();
         return;

--- a/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
+++ b/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
@@ -140,8 +140,6 @@ public abstract class BaseIntegrationTest {
       else if (log.isDebugEnabled())
         log.debug(event.cause().toString());
 
-      event.cause().printStackTrace();
-
       if (skipSyncCheck(schema)) {
         context.completeNow();
         return;


### PR DESCRIPTION
Now anyOf has a more verbose validation exception, for example:

```
ValidationException{message='anyOf subschemas don't match. Multiple causes: [input don't match any of types [INTEGER], value should be >= 2.0]', keyword='anyOf', input=1.5, schema=io.vertx.ext.json.schema.common.SchemaImpl@3b7d3a38, scope=file:///home/slinkydeveloper/projects/vertx-json-schema/src/test/resources/tck/draft2019-09/anyOf.json#}
```

On the schema

```
    {
      "anyOf": [
        {
          "type": "integer"
        },
        {
          "minimum": 2
        }
      ]
    }
```