### PR TITLE
Test logging was using slf4j, switched back to internal vertx logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,18 +90,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.21</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.25</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
+++ b/src/test/java/io/vertx/ext/json/schema/BaseIntegrationTest.java
@@ -8,6 +8,8 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.json.schema.common.SchemaRouterImpl;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -19,8 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 import java.io.IOException;
 import java.net.URISyntaxException;


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

