### PR TITLE
addJson + resolveCachedSchema issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <junit5.version>5.6.0</junit5.version>
+    <junit5.version>5.7.0</junit5.version>
     <mockito.version>3.3.0</mockito.version>
     <assertj.version>3.15.0</assertj.version>
     <doc.skip>false</doc.skip>

--- a/src/main/java/io/vertx/ext/json/schema/SchemaRouter.java
+++ b/src/main/java/io/vertx/ext/json/schema/SchemaRouter.java
@@ -109,6 +109,7 @@ public interface SchemaRouter {
    * @return a reference to this
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
   SchemaRouter addJson(URI uri, JsonObject object);
 
   /**
@@ -122,6 +123,7 @@ public interface SchemaRouter {
    * @param object
    * @return a reference to this
    */
+  @Fluent
   default SchemaRouter addJson(String uri, JsonObject object) {
     return addJson(URI.create(uri), object);
   }

--- a/src/main/java/io/vertx/ext/json/schema/common/URIUtils.java
+++ b/src/main/java/io/vertx/ext/json/schema/common/URIUtils.java
@@ -27,8 +27,7 @@ public class URIUtils {
         return new URI(oldURI.getScheme(), oldURI.getSchemeSpecificPart(), fragment);
       } else return new URI(null, null, fragment);
     } catch (URISyntaxException e) {
-      e.printStackTrace();
-      return null;
+      throw new IllegalArgumentException(e);
     }
   }
 
@@ -49,8 +48,7 @@ public class URIUtils {
       } else if (path.isEmpty()) return oldURI;
       else return oldURI.resolve(path);
     } catch (URISyntaxException e) {
-      e.printStackTrace();
-      return null;
+      throw new IllegalArgumentException(e);
     }
   }
 

--- a/src/main/java/io/vertx/ext/json/schema/common/URIUtils.java
+++ b/src/main/java/io/vertx/ext/json/schema/common/URIUtils.java
@@ -14,6 +14,7 @@ import io.vertx.core.json.pointer.JsonPointer;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 public class URIUtils {
 
@@ -64,6 +65,22 @@ public class URIUtils {
       if (frag.charAt(0) != '/') frag = "/" + frag;
     }
     return JsonPointer.fromURI(replaceFragment(original, frag));
+  }
+
+  public static URI requireAbsoluteUri(URI uri) {
+    Objects.requireNonNull(uri);
+    if (!uri.isAbsolute()) {
+      throw new IllegalArgumentException("Provided uri should be absolute. Actual: " + uri.toString());
+    }
+    return uri;
+  }
+
+  public static URI requireAbsoluteUri(URI uri, String name) {
+    Objects.requireNonNull(uri);
+    if (!uri.isAbsolute()) {
+      throw new IllegalArgumentException("Provided " + name + " uri should be absolute. Actual: " + uri.toString());
+    }
+    return uri;
   }
 
 }

--- a/src/test/java/io/vertx/ext/json/schema/common/SchemaRouterImplTest.java
+++ b/src/test/java/io/vertx/ext/json/schema/common/SchemaRouterImplTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class SchemaRouterImplTest {
 
   @Test
-  public void resolveCachedSchemaInJsonContainingSchemas(Vertx vertx) throws Exception {
+  public void resolveCachedSchemaInJsonContainingSchemasWithRelativeRef(Vertx vertx) throws Exception {
     final URI baseJsonUri = buildBaseUri("openapi.json");
     SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
     SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
@@ -36,12 +36,109 @@ public class SchemaRouterImplTest {
       schemaParser
     );
 
+    assertThat(schema)
+      .isNotNull();
     assertThat(schema.getJson())
       .isInstanceOf(JsonObject.class);
 
     assertThat((JsonObject) schema.getJson())
-      .extractingKey("description")
+      .extractingKey("title")
       .isEqualTo("Root Type for TrafficLight");
+  }
+
+  @Test
+  public void resolveCachedSchemaInJsonContainingSchemasWithAbsoluteRef(Vertx vertx) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.addJson(baseJsonUri, loadJson(baseJsonUri));
+
+    Schema schema = schemaRouter.resolveCachedSchema(
+      JsonPointer.fromURI(URIUtils.replaceFragment(baseJsonUri, "/components/schemas/TrafficLight")),
+      JsonPointer.create(),
+      schemaParser
+    );
+
+    assertThat(schema)
+      .isNotNull();
+    assertThat(schema.getJson())
+      .isInstanceOf(JsonObject.class);
+
+    assertThat((JsonObject) schema.getJson())
+      .extractingKey("title")
+      .isEqualTo("Root Type for TrafficLight");
+  }
+
+  @Test
+  public void resolveMultipleCachedSchemaInJsonContainingSchemasWithRelativeRef(Vertx vertx) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.addJson(baseJsonUri, loadJson(baseJsonUri));
+
+    Schema trafficLight = schemaRouter.resolveCachedSchema(
+      JsonPointer.from("/components/schemas/TrafficLight"),
+      JsonPointer.fromURI(baseJsonUri),
+      schemaParser
+    );
+
+    assertThat(trafficLight)
+      .isNotNull();
+    assertThat(trafficLight.getJson())
+      .isInstanceOf(JsonObject.class);
+    assertThat((JsonObject) trafficLight.getJson())
+      .extractingKey("title")
+      .isEqualTo("Root Type for TrafficLight");
+
+    Schema roadLayout = schemaRouter.resolveCachedSchema(
+      JsonPointer.from("/components/schemas/RoadLayout"),
+      JsonPointer.fromURI(baseJsonUri),
+      schemaParser
+    );
+    assertThat(roadLayout)
+      .isNotNull();
+    assertThat(roadLayout.getJson())
+      .isInstanceOf(JsonObject.class);
+    assertThat((JsonObject) roadLayout.getJson())
+      .extractingKey("title")
+      .isEqualTo("Root Type for RoadLayout");
+  }
+
+  @Test
+  public void resolveMultipleCachedSchemaInJsonContainingSchemasWithAbsoluteRef(Vertx vertx) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.addJson(baseJsonUri, loadJson(baseJsonUri));
+
+    Schema trafficLight = schemaRouter.resolveCachedSchema(
+      JsonPointer.fromURI(URIUtils.replaceFragment(baseJsonUri, "/components/schemas/TrafficLight")),
+      JsonPointer.create(),
+      schemaParser
+    );
+    assertThat(trafficLight)
+      .isNotNull();
+    assertThat(trafficLight.getJson())
+      .isInstanceOf(JsonObject.class);
+    assertThat((JsonObject) trafficLight.getJson())
+      .extractingKey("title")
+      .isEqualTo("Root Type for TrafficLight");
+
+    Schema roadLayout = schemaRouter.resolveCachedSchema(
+      JsonPointer.fromURI(URIUtils.replaceFragment(baseJsonUri, "/components/schemas/RoadLayout")),
+      JsonPointer.create(),
+      schemaParser
+    );
+    assertThat(roadLayout)
+      .isNotNull();
+    assertThat(roadLayout.getJson())
+      .isInstanceOf(JsonObject.class);
+    assertThat((JsonObject) roadLayout.getJson())
+      .extractingKey("title")
+      .isEqualTo("Root Type for RoadLayout");
   }
 
   @Test
@@ -63,7 +160,7 @@ public class SchemaRouterImplTest {
           assertThat(schema.getJson())
             .isInstanceOf(JsonObject.class);
           assertThat((JsonObject) schema.getJson())
-            .extractingKey("description")
+            .extractingKey("title")
             .isEqualTo("Root Type for TrafficLight");
         });
         testContext.completeNow();

--- a/src/test/java/io/vertx/ext/json/schema/common/SchemaRouterImplTest.java
+++ b/src/test/java/io/vertx/ext/json/schema/common/SchemaRouterImplTest.java
@@ -1,0 +1,99 @@
+package io.vertx.ext.json.schema.common;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.pointer.JsonPointer;
+import io.vertx.ext.json.schema.Schema;
+import io.vertx.ext.json.schema.SchemaParser;
+import io.vertx.ext.json.schema.SchemaRouter;
+import io.vertx.ext.json.schema.SchemaRouterOptions;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.net.URI;
+
+import static io.vertx.ext.json.schema.TestUtils.buildBaseUri;
+import static io.vertx.ext.json.schema.TestUtils.loadJson;
+import static io.vertx.ext.json.schema.asserts.MyAssertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class SchemaRouterImplTest {
+
+  @Test
+  public void resolveCachedSchemaInJsonContainingSchemas(Vertx vertx) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.addJson(baseJsonUri, loadJson(baseJsonUri));
+
+    Schema schema = schemaRouter.resolveCachedSchema(
+      JsonPointer.from("/components/schemas/TrafficLight"),
+      JsonPointer.fromURI(baseJsonUri),
+      schemaParser
+    );
+
+    assertThat(schema.getJson())
+      .isInstanceOf(JsonObject.class);
+
+    assertThat((JsonObject) schema.getJson())
+      .extractingKey("description")
+      .isEqualTo("Root Type for TrafficLight");
+  }
+
+  @Test
+  public void resolveRefInJsonContainingSchemasWithRelativeRef(Vertx vertx, VertxTestContext testContext) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.resolveRef(
+      JsonPointer.from("/components/schemas/TrafficLight"),
+      JsonPointer.fromURI(baseJsonUri),
+      schemaParser
+    )
+      .onFailure(testContext::failNow)
+      .onSuccess(schema -> {
+        testContext.verify(() -> {
+          assertThat(schema)
+            .isNotNull();
+          assertThat(schema.getJson())
+            .isInstanceOf(JsonObject.class);
+          assertThat((JsonObject) schema.getJson())
+            .extractingKey("description")
+            .isEqualTo("Root Type for TrafficLight");
+        });
+        testContext.completeNow();
+      });
+  }
+
+  @Test
+  public void resolveRefInJsonContainingSchemasWithAbsoluteRef(Vertx vertx, VertxTestContext testContext) throws Exception {
+    final URI baseJsonUri = buildBaseUri("openapi.json");
+    SchemaRouter schemaRouter = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser schemaParser = SchemaParser.createOpenAPI3SchemaParser(schemaRouter);
+
+    schemaRouter.resolveRef(
+      JsonPointer.fromURI(URIUtils.replaceFragment(baseJsonUri, "/components/schemas/TrafficLight")),
+      JsonPointer.create(),
+      schemaParser
+    )
+      .onFailure(testContext::failNow)
+      .onSuccess(schema -> {
+        testContext.verify(() -> {
+          assertThat(schema)
+            .isNotNull();
+          assertThat(schema.getJson())
+            .isInstanceOf(JsonObject.class);
+          assertThat((JsonObject) schema.getJson())
+            .extractingKey("title")
+            .isEqualTo("Root Type for TrafficLight");
+        });
+        testContext.completeNow();
+      });
+  }
+
+}

--- a/src/test/resources/openapi.json
+++ b/src/test/resources/openapi.json
@@ -5,116 +5,6 @@
     "version": "1.0.0",
     "description": "OpenAPI used to test the SchemaRouterImpl"
   },
-  "paths": {
-    "/roadlayouts": {
-      "summary": "Path used to manage the list of roadlayouts.",
-      "description": "The REST endpoint/path used to list and create zero or more `RoadLayout` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.",
-      "get": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RoadLayout"
-                  }
-                }
-              }
-            },
-            "description": "Successful response - returns an array of `RoadLayout` entities."
-          }
-        },
-        "operationId": "getroadlayouts",
-        "summary": "List All roadlayouts",
-        "description": "Gets a list of all `RoadLayout` entities."
-      },
-      "post": {
-        "requestBody": {
-          "description": "A new `RoadLayout` to be created.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RoadLayout"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful response."
-          }
-        },
-        "operationId": "createRoadLayout",
-        "summary": "Create a RoadLayout",
-        "description": "Creates a new instance of a `RoadLayout`."
-      }
-    },
-    "/roadlayouts/{roadlayoutId}": {
-      "summary": "Path used to manage a single RoadLayout.",
-      "description": "The REST endpoint/path used to get, update, and delete single instances of an `RoadLayout`.  This path contains `GET`, `PUT`, and `DELETE` operations used to perform the get, update, and delete tasks, respectively.",
-      "get": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RoadLayout"
-                }
-              }
-            },
-            "description": "Successful response - returns a single `RoadLayout`."
-          }
-        },
-        "operationId": "getRoadLayout",
-        "summary": "Get a RoadLayout",
-        "description": "Gets the details of a single instance of a `RoadLayout`."
-      },
-      "put": {
-        "requestBody": {
-          "description": "Updated `RoadLayout` information.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RoadLayout"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "description": "Successful response."
-          }
-        },
-        "operationId": "updateRoadLayout",
-        "summary": "Update a RoadLayout",
-        "description": "Updates an existing `RoadLayout`."
-      },
-      "delete": {
-        "responses": {
-          "204": {
-            "description": "Successful response."
-          }
-        },
-        "operationId": "deleteRoadLayout",
-        "summary": "Delete a RoadLayout",
-        "description": "Deletes an existing `RoadLayout`."
-      },
-      "parameters": [
-        {
-          "name": "roadlayoutId",
-          "description": "A unique identifier for a `RoadLayout`.",
-          "schema": {
-            "type": "string"
-          },
-          "in": "path",
-          "required": true
-        }
-      ]
-    }
-  },
   "components": {
     "schemas": {
       "TrafficLight": {
@@ -157,6 +47,7 @@
         }
       },
       "RoadLayout": {
+        "title": "Root Type for RoadLayout",
         "description": "An average road with all its traffic lights",
         "required": [
           "name"

--- a/src/test/resources/openapi.json
+++ b/src/test/resources/openapi.json
@@ -1,0 +1,191 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "SchemaDemo",
+    "version": "1.0.0",
+    "description": "OpenAPI used to test the SchemaRouterImpl"
+  },
+  "paths": {
+    "/roadlayouts": {
+      "summary": "Path used to manage the list of roadlayouts.",
+      "description": "The REST endpoint/path used to list and create zero or more `RoadLayout` entities.  This path contains a `GET` and `POST` operation to perform the list and create tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoadLayout"
+                  }
+                }
+              }
+            },
+            "description": "Successful response - returns an array of `RoadLayout` entities."
+          }
+        },
+        "operationId": "getroadlayouts",
+        "summary": "List All roadlayouts",
+        "description": "Gets a list of all `RoadLayout` entities."
+      },
+      "post": {
+        "requestBody": {
+          "description": "A new `RoadLayout` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoadLayout"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "createRoadLayout",
+        "summary": "Create a RoadLayout",
+        "description": "Creates a new instance of a `RoadLayout`."
+      }
+    },
+    "/roadlayouts/{roadlayoutId}": {
+      "summary": "Path used to manage a single RoadLayout.",
+      "description": "The REST endpoint/path used to get, update, and delete single instances of an `RoadLayout`.  This path contains `GET`, `PUT`, and `DELETE` operations used to perform the get, update, and delete tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoadLayout"
+                }
+              }
+            },
+            "description": "Successful response - returns a single `RoadLayout`."
+          }
+        },
+        "operationId": "getRoadLayout",
+        "summary": "Get a RoadLayout",
+        "description": "Gets the details of a single instance of a `RoadLayout`."
+      },
+      "put": {
+        "requestBody": {
+          "description": "Updated `RoadLayout` information.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoadLayout"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "updateRoadLayout",
+        "summary": "Update a RoadLayout",
+        "description": "Updates an existing `RoadLayout`."
+      },
+      "delete": {
+        "responses": {
+          "204": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "deleteRoadLayout",
+        "summary": "Delete a RoadLayout",
+        "description": "Deletes an existing `RoadLayout`."
+      },
+      "parameters": [
+        {
+          "name": "roadlayoutId",
+          "description": "A unique identifier for a `RoadLayout`.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    }
+  },
+  "components": {
+    "schemas": {
+      "TrafficLight": {
+        "title": "Root Type for TrafficLight",
+        "description": "",
+        "required": [
+          "color",
+          "location",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "color": {
+            "description": "Color of the traffic light, Red, Yellow, Green",
+            "enum": [
+              "red",
+              "yellow",
+              "green"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "description": "Who is it for",
+            "enum": [
+              "pedestrian",
+              "bicycle",
+              "motorvehicles"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "description": "Some address String",
+            "type": "string"
+          }
+        },
+        "example": {
+          "color": "red",
+          "type": "pedestrian",
+          "location": "21nd Street"
+        }
+      },
+      "RoadLayout": {
+        "description": "An average road with all its traffic lights",
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the streets",
+            "type": "string"
+          },
+          "description": {
+            "description": "What this street is about, best places",
+            "type": "string"
+          },
+          "trafficlights": {
+            "description": "List of all traffic lights in the street",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrafficLight"
+            }
+          }
+        },
+        "example": {
+          "name": "Sesame Street",
+          "description": "Home of the Big Bird",
+          "trafficlights": [
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a fix for the use case proposed by @Stwissel https://github.com/Stwissel/jsonmystery

* Now the resolution works properly if you add a json with `addJson` and then you query the schema router with `resolveCachedSchema`
* Now you cannot provide a schema without providing the absolute uri
* Nits + cleanups in URIUtils