### PR TITLE
Schema#getDefaultValue() throws NoSyncValidationException if it is a RefSchema

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -122,17 +122,6 @@ If you use {@link io.vertx.json.schema.Schema#validateAsync(Object)} while the s
 the schema will validate synchronously wrapping the result in the returned `Future`, avoiding unnecessary async computations and memory usage
 ====
 
-== Apply default values
-
-You can deeply apply default values to `JsonObject` and `JsonArray`:
-
-[source,$lang]
-----
-{@link examples.JsonSchemaExamples#applyDefaultValues}
-----
-
-These methods will mutate the internal state of the provided Json structures.
-
 == Adding custom formats
 
 You can add custom formats to use with validation keyword `format` before parsing the schemas:

--- a/src/main/java/examples/JsonSchemaExamples.java
+++ b/src/main/java/examples/JsonSchemaExamples.java
@@ -1,7 +1,6 @@
 package examples;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.docgen.Source;
@@ -44,12 +43,6 @@ public class JsonSchemaExamples {
         ar.cause(); // Contains ValidationException
       }
     });
-  }
-
-  public void applyDefaultValues(Schema schema, JsonObject jsonObject, JsonArray jsonArray) {
-    schema.applyDefaultValues(jsonObject);
-    // Or
-    schema.applyDefaultValues(jsonArray);
   }
 
   public void customFormat(SchemaParser parser) {

--- a/src/main/java/io/vertx/json/schema/Schema.java
+++ b/src/main/java/io/vertx/json/schema/Schema.java
@@ -12,8 +12,6 @@ package io.vertx.json.schema;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 
 /**
@@ -25,7 +23,7 @@ import io.vertx.core.json.pointer.JsonPointer;
  *   <li>Asynchronous: One or more branches of the validator tree requires an asynchronous validation, so you must use {@link this#validateAsync(Object)} to validate your json. If you use {@link this#validateSync(Object)} it will throw a {@link NoSyncValidationException}</li>
  * </ul>
  * <p>
- * To check the schema state you can use method {@link this#isSync()} <br/>
+ * To check the schema state you can use method {@link this#isSync()}. Note that invoking {@link #validateAsync(Object)} generally doesn't have any additional overhead than invoking {@link #validateSync(Object)}. <br/>
  * The schema can mutate the state in time, e.g. if you have a schema that is asynchronous because of a {@code $ref},
  * after the first validation the external schema is cached inside {@link SchemaRouter} and this schema will switch to synchronous state<br/>
  */
@@ -33,72 +31,36 @@ import io.vertx.core.json.pointer.JsonPointer;
 public interface Schema {
 
   /**
-   * Validate the json performing an asynchronous validation. Returns a failed future with {@link ValidationException} if json doesn't match the schema.<br/>
+   * Validate the json performing an asynchronous validation.<br/>
    * <p>
    * Note: If the schema is synchronous, this method will call internally {@link this#validateSync(Object)}
    *
-   * @param json
-   * @return
+   * @param json input to validate
+   * @return a failed future with {@link ValidationException} if json doesn't match the schema, otherwise a succeeded future.
    */
   Future<Void> validateAsync(Object json);
 
   /**
    * Validate the json performing a synchronous validation. Throws a {@link ValidationException} if json doesn't match the schema.<br/>
    *
-   * @param json
-   * @throws ValidationException
+   * @param json input to validate
+   * @throws ValidationException       if the input doesn't match the schema
    * @throws NoSyncValidationException If the schema cannot perform a synchronous validation
    */
   void validateSync(Object json) throws ValidationException, NoSyncValidationException;
 
   /**
-   * Get scope of this schema
-   *
-   * @return
+   * @return scope of this schema
    */
   JsonPointer getScope();
 
   /**
-   * Get Json representation of the schema
-   *
-   * @return
+   * @return Json representation of the schema
    */
   Object getJson();
 
   /**
-   * Return the default value defined in the schema
-   *
-   * @return
-   */
-  Object getDefaultValue();
-
-  /**
-   * Return true if the schema has a default value defined
-   *
-   * @return
-   */
-  boolean hasDefaultValue();
-
-  /**
-   * This function mutates {@code array} applying default values, when available.
-   *
-   * @param array
-   * @throws NoSyncValidationException if this schema represents a {@code $ref} not solved yet
-   */
-  void applyDefaultValues(JsonArray array) throws NoSyncValidationException;
-
-  /**
-   * This function mutates {@code object} applying default values, when available.
-   *
-   * @param object
-   * @throws NoSyncValidationException if this schema represents a {@code $ref} not solved yet
-   */
-  void applyDefaultValues(JsonObject object) throws NoSyncValidationException;
-
-  /**
-   * Returns true if this validator can actually provide a synchronous validation
-   *
-   * @return
+   * @return true if this validator can provide a synchronous validation.
    */
   boolean isSync();
 

--- a/src/main/java/io/vertx/json/schema/common/DefaultApplier.java
+++ b/src/main/java/io/vertx/json/schema/common/DefaultApplier.java
@@ -10,8 +10,10 @@
  */
 package io.vertx.json.schema.common;
 
+import io.vertx.core.Future;
+
 public interface DefaultApplier {
 
-  void applyDefaultValue(Object value);
+  Future<Void> applyDefaultValue(Object value);
 
 }

--- a/src/main/java/io/vertx/json/schema/common/FalseSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/FalseSchema.java
@@ -11,8 +11,6 @@
 package io.vertx.json.schema.common;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.ValidationException;
@@ -74,21 +72,13 @@ public class FalseSchema implements SchemaInternal {
   }
 
   @Override
-  public Object getDefaultValue() {
-    return null;
+  public Future<Object> getOrApplyDefaultAsync(Object input) {
+    return Future.succeededFuture(input);
   }
 
   @Override
-  public boolean hasDefaultValue() {
-    return false;
-  }
-
-  @Override
-  public void applyDefaultValues(JsonArray array) throws NoSyncValidationException {
-  }
-
-  @Override
-  public void applyDefaultValues(JsonObject object) throws NoSyncValidationException {
+  public Object getOrApplyDefaultSync(Object input) {
+    return input;
   }
 
 }

--- a/src/main/java/io/vertx/json/schema/common/RecursiveRefSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/RecursiveRefSchema.java
@@ -81,21 +81,6 @@ public class RecursiveRefSchema extends SchemaImpl {
   }
 
   @Override
-  public Object getDefaultValue() {
-    //TODO that requires the context!
-    return null;
-  }
-
-  @Override
-  public boolean hasDefaultValue() {
-    return false;
-  }
-
-  @Override
-  public void doApplyDefaultValues(Object obj) {
-  }
-
-  @Override
   public boolean isSync() {
     return false;
   }
@@ -123,6 +108,16 @@ public class RecursiveRefSchema extends SchemaImpl {
       return RecursiveAnchorValidatorContextDecorator.wrap(context, this.getScope());
     }
     return context;
+  }
+
+  @Override
+  public Future<Object> getOrApplyDefaultAsync(Object input) {
+    return Future.succeededFuture(input); // TODO Does it really makes sense default on $recursiveRef?
+  }
+
+  @Override
+  public Object getOrApplyDefaultSync(Object input) {
+    return input; // TODO Does it really makes sense default on $recursiveRef?
   }
 
 }

--- a/src/main/java/io/vertx/json/schema/common/RefSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/RefSchema.java
@@ -118,21 +118,17 @@ public class RefSchema extends SchemaImpl {
   }
 
   @Override
-  public Object getDefaultValue() {
-    this.checkSync();
-    return cachedSchema.getDefaultValue();
+  public Future<Object> getOrApplyDefaultAsync(Object input) {
+    if (this.isSync()) {
+      return Future.succeededFuture(getOrApplyDefaultSync(input));
+    }
+    return trySolveSchema().compose(schemaInternal -> schemaInternal.getOrApplyDefaultAsync(input));
   }
 
   @Override
-  public boolean hasDefaultValue() {
+  public Object getOrApplyDefaultSync(Object input) {
     this.checkSync();
-    return cachedSchema.hasDefaultValue();
-  }
-
-  @Override
-  public void doApplyDefaultValues(Object obj) {
-    this.checkSync();
-    ((SchemaImpl) cachedSchema).doApplyDefaultValues(obj);
+    return cachedSchema.getOrApplyDefaultSync(input);
   }
 
   synchronized Future<SchemaInternal> trySolveSchema() {

--- a/src/main/java/io/vertx/json/schema/common/SchemaInternal.java
+++ b/src/main/java/io/vertx/json/schema/common/SchemaInternal.java
@@ -10,10 +10,16 @@
  */
 package io.vertx.json.schema.common;
 
+import io.vertx.core.Future;
 import io.vertx.json.schema.Schema;
 
 /**
  * Schema should implement sync and async validator too
  */
 public interface SchemaInternal extends Schema, AsyncValidator, SyncValidator {
+
+  Future<Object> getOrApplyDefaultAsync(Object input);
+
+  Object getOrApplyDefaultSync(Object input);
+
 }

--- a/src/main/java/io/vertx/json/schema/common/TrueSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/TrueSchema.java
@@ -11,8 +11,6 @@
 package io.vertx.json.schema.common;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.ValidationException;
@@ -73,21 +71,13 @@ public class TrueSchema implements SchemaInternal {
   }
 
   @Override
-  public Object getDefaultValue() {
-    return null;
+  public Future<Object> getOrApplyDefaultAsync(Object input) {
+    return Future.succeededFuture(input);
   }
 
   @Override
-  public boolean hasDefaultValue() {
-    return false;
-  }
-
-  @Override
-  public void applyDefaultValues(JsonArray array) throws NoSyncValidationException {
-  }
-
-  @Override
-  public void applyDefaultValues(JsonObject object) throws NoSyncValidationException {
+  public Object getOrApplyDefaultSync(Object input) {
+    return input;
   }
 
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #33. Now the defaulting is properly "included" in the async/sync tree structure

Note: this PR includes a **breaking change** to `Schema` interface, hiding all the default related methods behind `SchemaInternal` (since they might be modified in future, and because the existing one were poorly thought, i believe it's better to keep these in an internal interface that we can freely break)