### PR TITLE
Trace the input context during validation and report it in the failure

### DIFF
--- a/src/main/java/examples/AsyncEnumValidator.java
+++ b/src/main/java/examples/AsyncEnumValidator.java
@@ -8,7 +8,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.json.schema.common.BaseAsyncValidator;
 import io.vertx.json.schema.common.ValidatorContext;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 class AsyncEnumValidator extends BaseAsyncValidator {
 
@@ -27,7 +27,7 @@ class AsyncEnumValidator extends BaseAsyncValidator {
     vertx.eventBus().request(address, new JsonObject(), ar -> {
       JsonArray enumValues = (JsonArray) ar.result().body();
       if (!enumValues.contains(in))
-        promise.fail(createException("Not matching async enum " + enumValues, "asyncEnum", in));
+        promise.fail(create("Not matching async enum " + enumValues, "asyncEnum", in));
       else
         promise.complete();
     });

--- a/src/main/java/examples/PropertiesMultipleOfValidator.java
+++ b/src/main/java/examples/PropertiesMultipleOfValidator.java
@@ -19,7 +19,7 @@ public class PropertiesMultipleOfValidator extends BaseSyncValidator {
     if (in instanceof JsonObject) { // If it's not an object, we skip the validation
       if (((JsonObject) in).size() % multipleOf != 0) {
         throw ValidationException
-          .createException(
+          .create(
             "The provided object size is not a multiple of " + multipleOf,
             "propertiesMultipleOf",
             in

--- a/src/main/java/io/vertx/json/schema/ValidationException.java
+++ b/src/main/java/io/vertx/json/schema/ValidationException.java
@@ -39,6 +39,30 @@ public abstract class ValidationException extends VertxException {
     this.input = input;
   }
 
+  /**
+   * @deprecated just use {@link #create(String, String, Object, Collection)}
+   */
+  @Deprecated
+  public static ValidationException createException(String message, String keyword, Object input, Collection<Throwable> causes) {
+    return new ValidationExceptionImpl(message, causes, keyword, input);
+  }
+
+  /**
+   * @deprecated just use {@link #create(String, String, Object, Throwable)}
+   */
+  @Deprecated
+  public static ValidationException createException(String message, String keyword, Object input, Throwable cause) {
+    return new ValidationExceptionImpl(message, cause, keyword, input);
+  }
+
+  /**
+   * @deprecated just use {@link #create(String, String, Object)}
+   */
+  @Deprecated
+  public static ValidationException createException(String message, String keyword, Object input) {
+    return new ValidationExceptionImpl(message, keyword, input);
+  }
+
   public static ValidationException create(String message, String keyword, Object input, Collection<Throwable> causes) {
     return new ValidationExceptionImpl(message, causes, keyword, input);
   }

--- a/src/main/java/io/vertx/json/schema/common/AnyOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/AnyOfValidatorFactory.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.vertx.json.schema.ValidationException.createException;
-
 public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
 
   @Override
@@ -57,7 +55,7 @@ public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
           res.add(e);
         }
       }
-      throw createException(
+      throw ValidationException.create(
         "anyOf subschemas don't match",
         "anyOf",
         in,
@@ -75,7 +73,7 @@ public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
             return Future.succeededFuture();
           } else {
             return Future.failedFuture(
-              createException(
+              ValidationException.create(
                 "anyOf subschemas don't match",
                 "anyOf",
                 in,

--- a/src/main/java/io/vertx/json/schema/common/BaseFormatValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/BaseFormatValidatorFactory.java
@@ -100,7 +100,7 @@ public abstract class BaseFormatValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof String) {
         if (!validator.test((String) in)) {
-          throw ValidationException.createException("Provided value don't match pattern", "pattern", in);
+          throw ValidationException.create("Provided value don't match pattern", "pattern", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/ConstValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ConstValidatorFactory.java
@@ -44,7 +44,7 @@ public class ConstValidatorFactory implements ValidatorFactory {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (!ComparisonUtils.equalsNumberSafe(allowedValue, in))
-        throw ValidationException.createException("Input doesn't match const: " + allowedValue, "const", in);
+        throw ValidationException.create("Input doesn't match const: " + allowedValue, "const", in);
     }
   }
 

--- a/src/main/java/io/vertx/json/schema/common/EnumValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/EnumValidatorFactory.java
@@ -67,7 +67,7 @@ public class EnumValidatorFactory implements ValidatorFactory {
         if (ComparisonUtils.equalsNumberSafe(allowedValues[i], in))
           return;
       }
-      throw ValidationException.createException("Input doesn't match one of allowed values of enum: " + Arrays.toString(allowedValues), "enum", in);
+      throw ValidationException.create("Input doesn't match one of allowed values of enum: " + Arrays.toString(allowedValues), "enum", in);
     }
   }
 

--- a/src/main/java/io/vertx/json/schema/common/ExclusiveMaximumValidator.java
+++ b/src/main/java/io/vertx/json/schema/common/ExclusiveMaximumValidator.java
@@ -12,7 +12,7 @@ package io.vertx.json.schema.common;
 
 import io.vertx.json.schema.ValidationException;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 public class ExclusiveMaximumValidator extends BaseSyncValidator {
   private final double maximum;
@@ -25,7 +25,7 @@ public class ExclusiveMaximumValidator extends BaseSyncValidator {
   public void validateSync(ValidatorContext context, Object in) throws ValidationException {
     if (in instanceof Number) {
       if (((Number) in).doubleValue() >= maximum) {
-        throw createException("value should be < " + maximum, "maximum", in);
+        throw create("value should be < " + maximum, "maximum", in);
       }
     }
   }

--- a/src/main/java/io/vertx/json/schema/common/ExclusiveMinimumValidator.java
+++ b/src/main/java/io/vertx/json/schema/common/ExclusiveMinimumValidator.java
@@ -23,7 +23,7 @@ public class ExclusiveMinimumValidator extends BaseSyncValidator {
   public void validateSync(ValidatorContext context, Object in) throws ValidationException {
     if (in instanceof Number) {
       if (((Number) in).doubleValue() <= minimum) {
-        throw ValidationException.createException("value should be > " + minimum, "minimum", in);
+        throw ValidationException.create("value should be > " + minimum, "minimum", in);
       }
     }
   }

--- a/src/main/java/io/vertx/json/schema/common/FalseSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/FalseSchema.java
@@ -43,12 +43,12 @@ public class FalseSchema implements SchemaInternal {
 
   @Override
   public void validateSync(Object in) throws ValidationException, NoSyncValidationException {
-    throw ValidationException.createException("False schema always fail validation", null, in);
+    throw ValidationException.create("False schema always fail validation", null, in);
   }
 
   @Override
   public Future<Void> validateAsync(Object in) {
-    return Future.failedFuture(ValidationException.createException("False schema always fail validation", null, in));
+    return Future.failedFuture(ValidationException.create("False schema always fail validation", null, in));
   }
 
   @Override

--- a/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
@@ -44,7 +44,7 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
         JsonArray arr = (JsonArray) in;
         for (int i = 0; i < arr.size(); i++) {
           context.markEvaluatedItem(i);
-          schema.validateSync(context.lowerLevelContext(), arr.getValue(i));
+          schema.validateSync(context.lowerLevelContext(i), arr.getValue(i));
         }
       }
     }
@@ -57,7 +57,7 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
         List<Future> futs = new ArrayList<>();
         for (int i = 0; i < arr.size(); i++) {
           context.markEvaluatedItem(i);
-          Future<Void> f = schema.validateAsync(context.lowerLevelContext(), arr.getValue(i));
+          Future<Void> f = schema.validateAsync(context.lowerLevelContext(i), arr.getValue(i));
           if (f.isComplete()) {
             if (f.failed()) return Future.failedFuture(f.cause());
           } else {

--- a/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
@@ -48,7 +48,7 @@ public class MaxItemsValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof JsonArray) {
         if (((JsonArray) in).size() > maximum) {
-          throw ValidationException.createException("provided array should have size <= " + maximum, "maxItems", in);
+          throw ValidationException.create("provided array should have size <= " + maximum, "maxItems", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MaxLengthValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxLengthValidatorFactory.java
@@ -47,7 +47,7 @@ public class MaxLengthValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof String) {
         if (((String) in).codePointCount(0, ((String) in).length()) > maximum) {
-          throw ValidationException.createException("provided string should have size <= " + maximum, "maxLength", in);
+          throw ValidationException.create("provided string should have size <= " + maximum, "maxLength", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
@@ -47,7 +47,7 @@ public class MaxPropertiesValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof JsonObject) {
         if (((JsonObject) in).size() > maximum) {
-          throw ValidationException.createException("provided object should have size <= " + maximum, "maxProperties", in);
+          throw ValidationException.create("provided object should have size <= " + maximum, "maxProperties", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MaximumValidator.java
+++ b/src/main/java/io/vertx/json/schema/common/MaximumValidator.java
@@ -23,7 +23,7 @@ public class MaximumValidator extends BaseSyncValidator {
   public void validateSync(ValidatorContext context, Object in) throws ValidationException {
     if (in instanceof Number) {
       if (((Number) in).doubleValue() > maximum) {
-        throw ValidationException.createException("value should be <= " + maximum, "maximum", in);
+        throw ValidationException.create("value should be <= " + maximum, "maximum", in);
       }
     }
   }

--- a/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
@@ -48,7 +48,7 @@ public class MinItemsValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof JsonArray) {
         if (((JsonArray) in).size() < minimum) {
-          throw ValidationException.createException("provided array should have size >= " + minimum, "minItems", in);
+          throw ValidationException.create("provided array should have size >= " + minimum, "minItems", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinLengthValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinLengthValidatorFactory.java
@@ -47,7 +47,7 @@ public class MinLengthValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof String) {
         if (((String) in).codePointCount(0, ((String) in).length()) < minimum) {
-          throw ValidationException.createException("provided string should have size >= " + minimum, "minLength", in);
+          throw ValidationException.create("provided string should have size >= " + minimum, "minLength", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
@@ -47,7 +47,7 @@ public class MinPropertiesValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof JsonObject) {
         if (((JsonObject) in).size() < minimum) {
-          throw ValidationException.createException("provided object should have size >= " + minimum, "minProperties", in);
+          throw ValidationException.create("provided object should have size >= " + minimum, "minProperties", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinimumValidator.java
+++ b/src/main/java/io/vertx/json/schema/common/MinimumValidator.java
@@ -23,7 +23,7 @@ public class MinimumValidator extends BaseSyncValidator {
   public void validateSync(ValidatorContext context, Object in) throws ValidationException {
     if (in instanceof Number) {
       if (((Number) in).doubleValue() < minimum) {
-        throw ValidationException.createException("value should be >= " + minimum, "minimum", in);
+        throw ValidationException.create("value should be >= " + minimum, "minimum", in);
       }
     }
   }

--- a/src/main/java/io/vertx/json/schema/common/MultipleOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MultipleOfValidatorFactory.java
@@ -45,7 +45,7 @@ public class MultipleOfValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in instanceof Number) {
         if (((Number) in).doubleValue() % multipleOf != 0) {
-          throw ValidationException.createException("provided number should be multiple of " + multipleOf, "multipleOf", in);
+          throw ValidationException.create("provided number should be multiple of " + multipleOf, "multipleOf", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/NoopValidatorContext.java
+++ b/src/main/java/io/vertx/json/schema/common/NoopValidatorContext.java
@@ -18,17 +18,22 @@ import java.util.Set;
  */
 public class NoopValidatorContext implements ValidatorContext {
 
-  private static class NoopValidatorContextHolder {
-    static final NoopValidatorContext INSTANCE = new NoopValidatorContext();
+  final private ValidatorContext parent;
+  final private String inputKey;
+
+  public NoopValidatorContext() {
+    this.parent = null;
+    this.inputKey = null;
   }
 
-  public static NoopValidatorContext getInstance() {
-    return NoopValidatorContext.NoopValidatorContextHolder.INSTANCE;
+  public NoopValidatorContext(ValidatorContext parent, String inputKey) {
+    this.parent = parent;
+    this.inputKey = inputKey;
   }
 
   @Override
   public ValidatorContext startRecording() {
-    return new RecordingValidatorContext();
+    return new RecordingValidatorContext(parent, inputKey);
   }
 
   @Override
@@ -50,7 +55,22 @@ public class NoopValidatorContext implements ValidatorContext {
   }
 
   @Override
-  public ValidatorContext lowerLevelContext() {
-    return this;
+  public ValidatorContext lowerLevelContext(String key) {
+    return new NoopValidatorContext(this, key);
+  }
+
+  @Override
+  public ValidatorContext lowerLevelContext(int key) {
+    return new NoopValidatorContext(this, Integer.toString(key));
+  }
+
+  @Override
+  public ValidatorContext parent() {
+    return parent;
+  }
+
+  @Override
+  public String inputKey() {
+    return inputKey;
   }
 }

--- a/src/main/java/io/vertx/json/schema/common/NotValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/NotValidatorFactory.java
@@ -44,7 +44,7 @@ public class NotValidatorFactory extends BaseSingleSchemaValidatorFactory {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
-      if (isValidSync(context, in)) throw ValidationException.createException("input should be invalid", "not", in);
+      if (isValidSync(context, in)) throw ValidationException.create("input should be invalid", "not", in);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class NotValidatorFactory extends BaseSingleSchemaValidatorFactory {
       return schema
         .validateAsync(context, in)
         .compose(
-          res -> Future.failedFuture(ValidationException.createException("input should be invalid", "not", in)),
+          res -> Future.failedFuture(ValidationException.create("input should be invalid", "not", in)),
           err -> Future.succeededFuture()
         );
     }

--- a/src/main/java/io/vertx/json/schema/common/OneOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/OneOfValidatorFactory.java
@@ -17,8 +17,6 @@ import io.vertx.json.schema.ValidationException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import static io.vertx.json.schema.ValidationException.createException;
-
 public class OneOfValidatorFactory extends BaseCombinatorsValidatorFactory {
 
   @Override
@@ -50,8 +48,8 @@ public class OneOfValidatorFactory extends BaseCombinatorsValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
       long validCount = Arrays.stream(schemas).map(s -> isValidSync(s, context, in)).filter(b -> b.equals(true)).count();
-      if (validCount > 1) throw ValidationException.createException("More than one schema valid", "oneOf", in);
-      else if (validCount == 0) throw ValidationException.createException("No schema matches", "oneOf", in);
+      if (validCount > 1) throw ValidationException.create("More than one schema valid", "oneOf", in);
+      else if (validCount == 0) throw ValidationException.create("No schema matches", "oneOf", in);
     }
 
     @Override
@@ -59,7 +57,7 @@ public class OneOfValidatorFactory extends BaseCombinatorsValidatorFactory {
       if (isSync()) return validateSyncAsAsync(context, in);
       return FutureUtils
         .oneOf(Arrays.stream(schemas).map(s -> s.validateAsync(context, in)).collect(Collectors.toList()))
-        .recover(err -> Future.failedFuture(createException("No schema matches", "oneOf", in, err)));
+        .recover(err -> Future.failedFuture(ValidationException.create("No schema matches", "oneOf", in, err)));
     }
   }
 

--- a/src/main/java/io/vertx/json/schema/common/PatternValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PatternValidatorFactory.java
@@ -52,7 +52,7 @@ public class PatternValidatorFactory implements ValidatorFactory {
       if (in instanceof String) {
         Matcher m = pattern.matcher((String) in);
         if (!(m.matches() || m.lookingAt() || m.find())) {
-          throw ValidationException.createException("provided string should respect pattern " + pattern, "pattern", in);
+          throw ValidationException.create("provided string should respect pattern " + pattern, "pattern", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 public class PropertiesValidatorFactory implements ValidatorFactory {
 
@@ -107,7 +107,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
   }
 
   private Future<Void> fillAdditionalPropertyException(Throwable t, Object in) {
-    return Future.failedFuture(createException("additionalProperties schema should match", "additionalProperties", in, t));
+    return Future.failedFuture(ValidationException.create("additionalProperties schema should match", "additionalProperties", in, t));
   }
 
   class PropertiesValidator extends BaseMutableStateValidator implements DefaultApplier {
@@ -161,12 +161,12 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
             context.markEvaluatedProperty(key);
             if (s.isSync()) {
               try {
-                s.validateSync(context.lowerLevelContext(), obj.getValue(key));
+                s.validateSync(context.lowerLevelContext(key), obj.getValue(key));
               } catch (ValidationException e) {
                 return Future.failedFuture(e);
               }
             } else {
-              futs.add(s.validateAsync(context.lowerLevelContext(), obj.getValue(key)));
+              futs.add(s.validateAsync(context.lowerLevelContext(key), obj.getValue(key)));
             }
             found = true;
           }
@@ -177,12 +177,12 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
                 context.markEvaluatedProperty(key);
                 if (s.isSync()) {
                   try {
-                    s.validateSync(context.lowerLevelContext(), obj.getValue(key));
+                    s.validateSync(context.lowerLevelContext(key), obj.getValue(key));
                   } catch (ValidationException e) {
                     return Future.failedFuture(e);
                   }
                 } else {
-                  futs.add(s.validateAsync(context.lowerLevelContext(), obj.getValue(key)));
+                  futs.add(s.validateAsync(context.lowerLevelContext(key), obj.getValue(key)));
                 }
                 found = true;
               }
@@ -194,19 +194,19 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
                 context.markEvaluatedProperty(key);
                 if (additionalPropertiesSchema.isSync()) {
                   try {
-                    additionalPropertiesSchema.validateSync(context.lowerLevelContext(), obj.getValue(key));
+                    additionalPropertiesSchema.validateSync(context.lowerLevelContext(key), obj.getValue(key));
                   } catch (ValidationException e) {
                     return fillAdditionalPropertyException(e, in);
                   }
                 } else {
                   futs.add(additionalPropertiesSchema
-                    .validateAsync(context.lowerLevelContext(), obj.getValue(key))
+                    .validateAsync(context.lowerLevelContext(key), obj.getValue(key))
                     .recover(t -> fillAdditionalPropertyException(t, in))
                   );
                 }
               }
             } else {
-              return Future.failedFuture(createException("provided object should not contain additional properties", "additionalProperties", in));
+              return Future.failedFuture(create("provided object should not contain additional properties", "additionalProperties", in));
             }
           }
         }
@@ -225,7 +225,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
           if (properties != null && properties.containsKey(key)) {
             SchemaInternal s = properties.get(key);
             context.markEvaluatedProperty(key);
-            s.validateSync(context.lowerLevelContext(), obj.getValue(key));
+            s.validateSync(context.lowerLevelContext(key), obj.getValue(key));
             found = true;
           }
           if (patternProperties != null) {
@@ -233,7 +233,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
               if (patternProperty.getKey().matcher(key).find()) {
                 SchemaInternal s = patternProperty.getValue();
                 context.markEvaluatedProperty(key);
-                s.validateSync(context.lowerLevelContext(), obj.getValue(key));
+                s.validateSync(context.lowerLevelContext(key), obj.getValue(key));
                 found = true;
               }
             }
@@ -242,10 +242,10 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
             if (allowAdditionalProperties) {
               if (additionalPropertiesSchema != null) {
                 context.markEvaluatedProperty(key);
-                additionalPropertiesSchema.validateSync(context.lowerLevelContext(), obj.getValue(key));
+                additionalPropertiesSchema.validateSync(context.lowerLevelContext(key), obj.getValue(key));
               }
             } else {
-              throw createException("provided object should not contain additional properties", "additionalProperties", in);
+              throw create("provided object should not contain additional properties", "additionalProperties", in);
             }
           }
         }

--- a/src/main/java/io/vertx/json/schema/common/RecordingValidatorContext.java
+++ b/src/main/java/io/vertx/json/schema/common/RecordingValidatorContext.java
@@ -16,8 +16,15 @@ import java.util.Set;
 
 public class RecordingValidatorContext implements ValidatorContext {
 
-  Set<Integer> evaluatedItems;
-  Set<String> evaluatedProperties;
+  final private ValidatorContext parent;
+  final private String inputKey;
+  private Set<Integer> evaluatedItems;
+  private Set<String> evaluatedProperties;
+
+  public RecordingValidatorContext(ValidatorContext parent, String key) {
+    this.parent = parent;
+    this.inputKey = key;
+  }
 
   @Override
   public ValidatorContext startRecording() {
@@ -51,8 +58,23 @@ public class RecordingValidatorContext implements ValidatorContext {
   }
 
   @Override
-  public ValidatorContext lowerLevelContext() {
-    return NoopValidatorContext.getInstance();
+  public ValidatorContext lowerLevelContext(String key) {
+    return new NoopValidatorContext(this, key);
+  }
+
+  @Override
+  public ValidatorContext lowerLevelContext(int key) {
+    return new NoopValidatorContext(this, Integer.toString(key));
+  }
+
+  @Override
+  public ValidatorContext parent() {
+    return this.parent;
+  }
+
+  @Override
+  public String inputKey() {
+    return this.inputKey;
   }
 
 }

--- a/src/main/java/io/vertx/json/schema/common/RecursiveAnchorValidatorContextDecorator.java
+++ b/src/main/java/io/vertx/json/schema/common/RecursiveAnchorValidatorContextDecorator.java
@@ -50,8 +50,23 @@ public class RecursiveAnchorValidatorContextDecorator implements ValidatorContex
   }
 
   @Override
-  public ValidatorContext lowerLevelContext() {
-    return wrapNewContext(this.context.lowerLevelContext());
+  public ValidatorContext lowerLevelContext(String key) {
+    return wrapNewContext(this.context.lowerLevelContext(key));
+  }
+
+  @Override
+  public ValidatorContext lowerLevelContext(int key) {
+    return wrapNewContext(this.context.lowerLevelContext(key));
+  }
+
+  @Override
+  public ValidatorContext parent() {
+    return this.context.parent();
+  }
+
+  @Override
+  public String inputKey() {
+    return this.context.inputKey();
   }
 
   public JsonPointer getRecursiveAnchor() {

--- a/src/main/java/io/vertx/json/schema/common/RecursiveRefSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/RecursiveRefSchema.java
@@ -22,7 +22,7 @@ import io.vertx.json.schema.ValidationException;
 
 import java.net.URI;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 public class RecursiveRefSchema extends SchemaImpl {
 
@@ -54,10 +54,10 @@ public class RecursiveRefSchema extends SchemaImpl {
     try {
       solvedSchema = resolveSchema(inContext);
     } catch (SchemaException e) {
-      return Future.failedFuture(createException("Error while resolving $recursiveRef " + refPointer.toURI(), "$recursiveRef", in, e));
+      return Future.failedFuture(ValidationException.create("Error while resolving $recursiveRef " + refPointer.toURI(), "$recursiveRef", in, e));
     }
     if (solvedSchema == null) {
-      return Future.failedFuture(createException("Cannot resolve $recursiveRef " + refPointer.toURI(), "$recursiveRef", in));
+      return Future.failedFuture(create("Cannot resolve $recursiveRef " + refPointer.toURI(), "$recursiveRef", in));
     }
 
     ValidatorContext newContext = generateValidationContext(solvedSchema, inContext);

--- a/src/main/java/io/vertx/json/schema/common/RefSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/RefSchema.java
@@ -65,7 +65,7 @@ public class RefSchema extends SchemaImpl {
         .compose(
           s -> {
             if (s == null)
-              return Future.failedFuture(ValidationException.createException("Cannot resolve reference " + this.refPointer.toURI(), "$ref", in));
+              return Future.failedFuture(ValidationException.create("Cannot resolve reference " + this.refPointer.toURI(), "$ref", in));
             SchemaInternal solvedSchema = (SchemaInternal) s;
             registerCachedSchema(solvedSchema);
             if (solvedSchema instanceof RefSchema) {
@@ -79,7 +79,7 @@ public class RefSchema extends SchemaImpl {
               return solvedSchema.validateAsync(context, in);
             }
           },
-          err -> Future.failedFuture(ValidationException.createException("Error while resolving reference " + this.refPointer.toURI(), "$ref", in, err))
+          err -> Future.failedFuture(ValidationException.create("Error while resolving reference " + this.refPointer.toURI(), "$ref", in, err))
         );
       if (executeSchemaValidators) {
         return fut.compose(v -> this.runAsyncValidators(context, in));
@@ -139,7 +139,7 @@ public class RefSchema extends SchemaImpl {
         .compose(
           s -> {
             if (s == null)
-              return Future.failedFuture(ValidationException.createException("Cannot resolve reference " + this.refPointer.toURI(), "$ref", null));
+              return Future.failedFuture(ValidationException.create("Cannot resolve reference " + this.refPointer.toURI(), "$ref", null));
             registerCachedSchema((SchemaInternal) s);
             if (s instanceof RefSchema) {
               // We need to call solved schema validateAsync to solve upper ref, then we can update sync status
@@ -152,7 +152,7 @@ public class RefSchema extends SchemaImpl {
               return Future.succeededFuture(cachedSchema);
             }
           },
-          err -> Future.failedFuture(ValidationException.createException("Error while resolving reference " + this.refPointer.toURI(), "$ref", null, err))
+          err -> Future.failedFuture(ValidationException.create("Error while resolving reference " + this.refPointer.toURI(), "$ref", null, err))
         );
     } else return Future.succeededFuture(cachedSchema);
   }

--- a/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
@@ -19,7 +19,7 @@ import io.vertx.json.schema.ValidationException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 public class RequiredValidatorFactory implements ValidatorFactory {
 
@@ -53,7 +53,7 @@ public class RequiredValidatorFactory implements ValidatorFactory {
         JsonObject obj = (JsonObject) in;
         for (String k : requiredKeys) {
           if (!obj.containsKey(k))
-            throw createException("provided object should contain property " + k, "required", in);
+            throw create("provided object should contain property " + k, "required", in);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/UniqueItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/UniqueItemsValidatorFactory.java
@@ -19,7 +19,7 @@ import io.vertx.json.schema.ValidationException;
 
 import java.util.HashSet;
 
-import static io.vertx.json.schema.ValidationException.createException;
+import static io.vertx.json.schema.ValidationException.create;
 
 public class UniqueItemsValidatorFactory implements ValidatorFactory {
 
@@ -29,7 +29,7 @@ public class UniqueItemsValidatorFactory implements ValidatorFactory {
       if (in instanceof JsonArray) {
         JsonArray arr = (JsonArray) in;
         if (new HashSet(arr.getList()).size() != arr.size())
-          throw createException("array elements must be unique", "uniqueItems", in);
+          throw create("array elements must be unique", "uniqueItems", in);
       }
     }
   };

--- a/src/main/java/io/vertx/json/schema/common/ValidationExceptionImpl.java
+++ b/src/main/java/io/vertx/json/schema/common/ValidationExceptionImpl.java
@@ -1,0 +1,43 @@
+package io.vertx.json.schema.common;
+
+import io.vertx.core.json.pointer.JsonPointer;
+import io.vertx.json.schema.Schema;
+import io.vertx.json.schema.ValidationException;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ValidationExceptionImpl extends ValidationException {
+
+  public ValidationExceptionImpl(String message, String keyword, Object input) {
+    super(message, keyword, input);
+  }
+
+  public ValidationExceptionImpl(String message, Throwable cause, String keyword, Object input) {
+    super(message, cause, keyword, input);
+  }
+
+  public ValidationExceptionImpl(String message, Collection<Throwable> causes, String keyword, Object input) {
+    super(message + ". Multiple causes: " + formatExceptions(causes), keyword, input);
+  }
+
+  public void setSchema(Schema schema) {
+    this.schema = schema;
+  }
+
+  public void setInputScope(JsonPointer scope) {
+    this.inputScope = scope;
+  }
+
+  private static String formatExceptions(Collection<Throwable> throwables) {
+    if (throwables == null) {
+      return "[]";
+    }
+    return "[" + throwables
+      .stream()
+      .filter(Objects::nonNull)
+      .map(Throwable::getMessage)
+      .collect(Collectors.joining(", ")) + "]";
+  }
+}

--- a/src/main/java/io/vertx/json/schema/common/ValidatorContext.java
+++ b/src/main/java/io/vertx/json/schema/common/ValidatorContext.java
@@ -13,7 +13,7 @@ package io.vertx.json.schema.common;
 import java.util.Set;
 
 /**
- * Validator context is an interface used to process contextual keywords (like unevaluatedProperties, unevaluatedItems)
+ * Validator context is an interface used to process contextual keywords (like unevaluatedProperties, unevaluatedItems) and trace the execution
  */
 public interface ValidatorContext {
 
@@ -27,6 +27,12 @@ public interface ValidatorContext {
 
   ValidatorContext startRecording();
 
-  ValidatorContext lowerLevelContext();
+  ValidatorContext lowerLevelContext(String key);
+
+  ValidatorContext lowerLevelContext(int key);
+
+  ValidatorContext parent();
+
+  String inputKey();
 
 }

--- a/src/main/java/io/vertx/json/schema/draft201909/DependentRequiredValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/DependentRequiredValidatorFactory.java
@@ -56,7 +56,7 @@ public class DependentRequiredValidatorFactory implements ValidatorFactory {
       Set<String> objKeys = obj.getMap().keySet();
       for (Map.Entry<String, Set<String>> dependency : keyDeps.entrySet()) {
         if (obj.containsKey(dependency.getKey()) && !objKeys.containsAll(dependency.getValue()))
-          throw ValidationException.createException("dependencies of key " + dependency.getKey() + " are not satisfied: " + dependency.getValue().toString(), "dependentRequired", obj);
+          throw ValidationException.create("dependencies of key " + dependency.getKey() + " are not satisfied: " + dependency.getValue().toString(), "dependentRequired", obj);
       }
     }
 

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
@@ -67,10 +67,10 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
         return CompositeFuture.all(
           unevaluatedItems
             .stream()
-            .map(index -> schema.validateAsync(context.lowerLevelContext(), array.getValue(index)))
+            .map(index -> schema.validateAsync(context.lowerLevelContext(index), array.getValue(index)))
             .collect(Collectors.toList())
         )
-          .recover(t -> Future.failedFuture(ValidationException.createException(
+          .recover(t -> Future.failedFuture(ValidationException.create(
             "one of the unevaluated items doesn't match the unevaluatedItems schema",
             "unevaluatedItems",
             in,
@@ -90,7 +90,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
         Set<Integer> unevaluatedProperties = computeUnevaluatedItems(context, array);
 
         unevaluatedProperties.forEach(index ->
-          schema.validateSync(context.lowerLevelContext(), array.getValue(index))
+          schema.validateSync(context.lowerLevelContext(index), array.getValue(index))
         );
       }
     }
@@ -114,7 +114,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       if (in instanceof JsonArray) {
         if (((JsonArray) in).size() != context.evaluatedItems().size()) {
-          throw ValidationException.createException(
+          throw ValidationException.create(
             "Expecting no unevaluated items. Unevaluated items: " +
               SetUtils.minus(
                 SetUtils.range(0, (((JsonArray) in).size())),

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
@@ -66,10 +66,10 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
         return CompositeFuture.all(
           unevaluatedItems
             .stream()
-            .map(key -> schema.validateAsync(context.lowerLevelContext(), obj.getValue(key)))
+            .map(key -> schema.validateAsync(context.lowerLevelContext(key), obj.getValue(key)))
             .collect(Collectors.toList())
         )
-          .recover(t -> Future.failedFuture(ValidationException.createException(
+          .recover(t -> Future.failedFuture(ValidationException.create(
             "one of the unevaluated properties doesn't match the unevaluatedProperties schema",
             "unevaluatedProperties",
             in,
@@ -89,7 +89,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
         Set<String> unevaluatedProperties = computeUnevaluatedProperties(context, obj);
 
         unevaluatedProperties.forEach(key ->
-          schema.validateSync(context.lowerLevelContext(), obj.getValue(key))
+          schema.validateSync(context.lowerLevelContext(key), obj.getValue(key))
         );
       }
     }
@@ -113,7 +113,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       if (in instanceof JsonObject) {
         if (!context.evaluatedProperties().containsAll(((JsonObject) in).fieldNames())) {
-          throw ValidationException.createException(
+          throw ValidationException.create(
             "Expecting no unevaluated properties. Unevaluated properties: " +
               SetUtils.minus(
                 ((JsonObject) in).fieldNames(),

--- a/src/main/java/io/vertx/json/schema/draft7/DependenciesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/DependenciesValidatorFactory.java
@@ -78,7 +78,7 @@ public class DependenciesValidatorFactory implements ValidatorFactory {
       Set<String> objKeys = obj.getMap().keySet();
       for (Map.Entry<String, Set<String>> dependency : keyDeps.entrySet()) {
         if (obj.containsKey(dependency.getKey()) && !objKeys.containsAll(dependency.getValue()))
-          throw ValidationException.createException("dependencies of key " + dependency.getKey() + " are not satisfied: " + dependency.getValue().toString(), "dependencies", obj);
+          throw ValidationException.create("dependencies of key " + dependency.getKey() + " are not satisfied: " + dependency.getValue().toString(), "dependencies", obj);
       }
     }
 

--- a/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
@@ -77,11 +77,11 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
           if (i >= schemas.length) {
             if (additionalItems != null) {
               context.markEvaluatedItem(i);
-              additionalItems.validateSync(context.lowerLevelContext(), arr.getValue(i));
+              additionalItems.validateSync(context.lowerLevelContext(i), arr.getValue(i));
             }
           } else {
             context.markEvaluatedItem(i);
-            schemas[i].validateSync(context.lowerLevelContext(), arr.getValue(i));
+            schemas[i].validateSync(context.lowerLevelContext(i), arr.getValue(i));
           }
         }
       }
@@ -98,11 +98,11 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
           if (i >= schemas.length) {
             if (additionalItems != null) {
               context.markEvaluatedItem(i);
-              fut = additionalItems.validateAsync(context.lowerLevelContext(), arr.getValue(i));
+              fut = additionalItems.validateAsync(context.lowerLevelContext(i), arr.getValue(i));
             } else continue;
           } else {
             context.markEvaluatedItem(i);
-            fut = schemas[i].validateAsync(context.lowerLevelContext(), arr.getValue(i));
+            fut = schemas[i].validateAsync(context.lowerLevelContext(i), arr.getValue(i));
           }
           if (fut.isComplete()) {
             if (fut.failed()) return Future.failedFuture(fut.cause());

--- a/src/main/java/io/vertx/json/schema/draft7/PropertyNamesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/PropertyNamesValidatorFactory.java
@@ -44,7 +44,7 @@ public class PropertyNamesValidatorFactory extends BaseSingleSchemaValidatorFact
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
       if (in instanceof JsonObject) {
-        ((JsonObject) in).getMap().keySet().forEach(k -> schema.validateSync(context.lowerLevelContext(), k));
+        ((JsonObject) in).getMap().keySet().forEach(k -> schema.validateSync(context, k));
       }
     }
 
@@ -55,11 +55,11 @@ public class PropertyNamesValidatorFactory extends BaseSingleSchemaValidatorFact
         return CompositeFuture.all(
           ((JsonObject) in).getMap().keySet()
             .stream()
-            .map(k -> schema.validateAsync(context.lowerLevelContext(), k))
+            .map(k -> schema.validateAsync(context, k))
             .collect(Collectors.toList())
         ).compose(
           cf -> Future.succeededFuture(),
-          err -> Future.failedFuture(ValidationException.createException("provided object contains a key not matching the propertyNames schema", "propertyNames", in, err))
+          err -> Future.failedFuture(ValidationException.create("provided object contains a key not matching the propertyNames schema", "propertyNames", in, err))
         );
       } else return Future.succeededFuture();
     }

--- a/src/main/java/io/vertx/json/schema/draft7/TypeValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/TypeValidatorFactory.java
@@ -89,9 +89,9 @@ public class TypeValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in != null) {
         for (JsonSchemaType type : types) if (type.checkInstance(in)) return;
-        throw ValidationException.createException("input don't match any of types " + Arrays.deepToString(types), "type", in);
+        throw ValidationException.create("input don't match any of types " + Arrays.deepToString(types), "type", in);
       } else if (!nullIsValid)
-        throw ValidationException.createException("input don't match any of types " + Arrays.deepToString(types), "type", in);
+        throw ValidationException.create("input don't match any of types " + Arrays.deepToString(types), "type", in);
     }
   }
 }

--- a/src/main/java/io/vertx/json/schema/openapi3/NullableValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/openapi3/NullableValidatorFactory.java
@@ -22,7 +22,7 @@ public class NullableValidatorFactory implements ValidatorFactory {
   private final static BaseSyncValidator NULL_VALIDATOR = new BaseSyncValidator() {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
-      if (in == null) throw ValidationException.createException("input cannot be null", "nullable", in);
+      if (in == null) throw ValidationException.create("input cannot be null", "nullable", in);
     }
   };
 

--- a/src/main/java/io/vertx/json/schema/openapi3/TypeValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/openapi3/TypeValidatorFactory.java
@@ -71,7 +71,7 @@ public class TypeValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
       if (in != null) {
         if (!type.checkInstance(in))
-          throw ValidationException.createException("input don't match type " + type.name(), "type", in);
+          throw ValidationException.create("input don't match type " + type.name(), "type", in);
       }
     }
   }

--- a/src/test/java/io/vertx/json/schema/asserts/SchemaAssert.java
+++ b/src/test/java/io/vertx/json/schema/asserts/SchemaAssert.java
@@ -11,8 +11,10 @@
 package io.vertx.json.schema.asserts;
 
 import io.vertx.json.schema.Schema;
+import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.SchemaImpl;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.StringAssert;
 
 import java.util.concurrent.CountDownLatch;
@@ -68,7 +70,7 @@ public class SchemaAssert extends AbstractAssert<SchemaAssert, Schema> {
     return this;
   }
 
-  public SchemaAssert validateAsyncFailure(Object in) {
+  public AbstractThrowableAssert<?, ValidationException> validateAsyncFailure(Object in) {
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<Throwable> ex = new AtomicReference<>();
     actual.validateAsync(in).onComplete(ar -> {
@@ -83,7 +85,7 @@ public class SchemaAssert extends AbstractAssert<SchemaAssert, Schema> {
     assertThat(ex.get())
       .withFailMessage("Expecting schema to validate with a failure")
       .isNotNull();
-    return this;
+    return (AbstractThrowableAssert<?, ValidationException>) assertThat((ValidationException) ex.get());
   }
 
 }

--- a/src/test/java/io/vertx/json/schema/common/SchemaImplTest.java
+++ b/src/test/java/io/vertx/json/schema/common/SchemaImplTest.java
@@ -1,0 +1,48 @@
+package io.vertx.json.schema.common;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.pointer.JsonPointer;
+import io.vertx.json.schema.Schema;
+import io.vertx.json.schema.TestUtils;
+import io.vertx.json.schema.ValidationException;
+import io.vertx.json.schema.draft7.Draft7SchemaParser;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static io.vertx.json.schema.asserts.MyAssertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+public class SchemaImplTest {
+
+  @Test
+  public void testFailureInputScope(Vertx vertx) throws IOException {
+    URI u = TestUtils.buildBaseUri("schema_impl_test", "arrays.json");
+    JsonObject obj = TestUtils.loadJson(u);
+    Schema schema = Draft7SchemaParser.parse(vertx, obj, u);
+
+    assertThat(schema)
+      .isSync();
+    assertThat(schema)
+      .validateAsyncFailure(10)
+      .extracting(ValidationException::inputScope)
+      .isEqualTo(JsonPointer.create());
+    assertThat(schema)
+      .validateAsyncFailure(new JsonObject().put("a", 0))
+      .extracting(ValidationException::inputScope)
+      .isEqualTo(JsonPointer.from("/a"));
+    assertThat(schema)
+      .validateAsyncFailure(new JsonObject().put("a", new JsonArray()
+        .add(new JsonObject().put("inner", 10))
+        .add(new JsonObject().put("inner", "fail"))
+      ))
+      .extracting(ValidationException::inputScope)
+      .isEqualTo(JsonPointer.from("/a/1/inner"));
+  }
+
+}

--- a/src/test/java/io/vertx/json/schema/custom/AsyncEnumValidatorFactory.java
+++ b/src/test/java/io/vertx/json/schema/custom/AsyncEnumValidatorFactory.java
@@ -61,7 +61,7 @@ public class AsyncEnumValidatorFactory implements ValidatorFactory {
       vertx.eventBus().request(address, new JsonObject(), ar -> {
         JsonArray enumValues = (JsonArray) ar.result().body();
         if (!enumValues.contains(in))
-          fut.fail(ValidationException.createException("Not matching async enum", "asyncEnum", in));
+          fut.fail(ValidationException.create("Not matching async enum", "asyncEnum", in));
         else fut.complete();
       });
       return fut.future();

--- a/src/test/java/io/vertx/json/schema/custom/CachedAsyncEnumValidatorFactory.java
+++ b/src/test/java/io/vertx/json/schema/custom/CachedAsyncEnumValidatorFactory.java
@@ -70,7 +70,7 @@ public class CachedAsyncEnumValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
       if (!this.cache.get().get().contains(in))
-        throw ValidationException.createException("Not matching cached async enum", "asyncEnum", in);
+        throw ValidationException.create("Not matching cached async enum", "asyncEnum", in);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class CachedAsyncEnumValidatorFactory implements ValidatorFactory {
         this.triggerUpdateIsSync();
 
         if (!enumValues.contains(in))
-          promise.fail(ValidationException.createException("Not matching async enum", "asyncEnum", in));
+          promise.fail(ValidationException.create("Not matching async enum", "asyncEnum", in));
         else promise.complete();
       });
       return promise.future();

--- a/src/test/java/io/vertx/json/schema/custom/PropertiesMultipleOfValidatorFactory.java
+++ b/src/test/java/io/vertx/json/schema/custom/PropertiesMultipleOfValidatorFactory.java
@@ -47,7 +47,7 @@ public class PropertiesMultipleOfValidatorFactory implements ValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       if (in instanceof JsonObject) {
         if (((JsonObject) in).size() % multipleOf != 0)
-          throw ValidationException.createException("The provided object size is not a multiple of " + multipleOf, "propertiesMultipleOf", in);
+          throw ValidationException.create("The provided object size is not a multiple of " + multipleOf, "propertiesMultipleOf", in);
       }
     }
   }

--- a/src/test/java/io/vertx/json/schema/draft201909/Draft201909Test.java
+++ b/src/test/java/io/vertx/json/schema/draft201909/Draft201909Test.java
@@ -69,8 +69,10 @@ public class Draft201909Test {
     Schema schema = parser.parse(schemaUnparsed, schemaURI);
 
     assertThat(schema)
-      .validateAsyncFailure(new JsonObject().put("id_card", 1))
-      .validateAsyncFailure(new JsonObject().put("id_card", "ABC"))
+      .validateAsyncFailure(new JsonObject().put("id_card", 1));
+    assertThat(schema)
+      .validateAsyncFailure(new JsonObject().put("id_card", "ABC"));
+    assertThat(schema)
       .validateAsyncSuccess(new JsonObject().put("id_card", "ABC").put("name", "Paolo").put("surname", "Rossi"))
       .isSync();
   }

--- a/src/test/resources/schema_impl_test/arrays.json
+++ b/src/test/resources/schema_impl_test/arrays.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "a": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "inner": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #32 

This includes:

* Refactored `ValidationException` to avoid exposing some internal methods (this includes some breaking changes)
* Now `ValidatorContext` records every time we walk one nested level into the json

Note: most of the changes are due to changes of `ValidationException` and `ValidatorContext`, the important bits to check are:

* https://github.com/eclipse-vertx/vertx-json-schema/pull/37/files#diff-052a6565a28b37e1b4c4c9a30fff0168cecab91fcba558589eec4ce3f3a0d38f
* https://github.com/eclipse-vertx/vertx-json-schema/pull/37/files#diff-b11a7c0376d336002dcabfae5c532b720af71f8784fab1bc691a124f896075c0
* https://github.com/eclipse-vertx/vertx-json-schema/pull/37/files#diff-d5029317d503231aabb32a69583222f92751c10358a74f6d33a82b720f27c156
* https://github.com/eclipse-vertx/vertx-json-schema/pull/37/files#diff-78829b6d36a24bd42ba336f908f81ce7749cfb8abf1e94b01b711460c800666c