### PR TITLE
Allow validation for not Vert.x JSON types

### DIFF
--- a/src/main/java/examples/AsyncEnumValidator.java
+++ b/src/main/java/examples/AsyncEnumValidator.java
@@ -12,8 +12,8 @@ import static io.vertx.json.schema.ValidationException.createException;
 
 class AsyncEnumValidator extends BaseAsyncValidator {
 
-  private Vertx vertx;
-  private String address;
+  private final Vertx vertx;
+  private final String address;
 
   public AsyncEnumValidator(Vertx vertx, String address) {
     this.vertx = vertx;

--- a/src/main/java/examples/AsyncEnumValidatorFactory.java
+++ b/src/main/java/examples/AsyncEnumValidatorFactory.java
@@ -13,7 +13,7 @@ public class AsyncEnumValidatorFactory implements ValidatorFactory {
 
   public final static String KEYWORD_NAME = "asyncEnum";
 
-  private Vertx vertx;
+  private final Vertx vertx;
 
   public AsyncEnumValidatorFactory(Vertx vertx) {
     this.vertx = vertx;

--- a/src/main/java/examples/PropertiesMultipleOfValidator.java
+++ b/src/main/java/examples/PropertiesMultipleOfValidator.java
@@ -8,7 +8,7 @@ import io.vertx.json.schema.common.ValidatorContext;
 
 public class PropertiesMultipleOfValidator extends BaseSyncValidator {
 
-  private int multipleOf;
+  private final int multipleOf;
 
   public PropertiesMultipleOfValidator(int multipleOf) {
     this.multipleOf = multipleOf;

--- a/src/main/java/io/vertx/json/schema/NoSyncValidationException.java
+++ b/src/main/java/io/vertx/json/schema/NoSyncValidationException.java
@@ -18,7 +18,7 @@ import io.vertx.json.schema.common.MutableStateValidator;
  */
 public class NoSyncValidationException extends VertxException {
 
-  private MutableStateValidator validator;
+  private final MutableStateValidator validator;
 
   public NoSyncValidationException(String message, MutableStateValidator validator) {
     super(message);

--- a/src/main/java/io/vertx/json/schema/SchemaException.java
+++ b/src/main/java/io/vertx/json/schema/SchemaException.java
@@ -19,7 +19,7 @@ import io.vertx.core.VertxException;
  */
 public class SchemaException extends VertxException {
 
-  private Object schema;
+  private final Object schema;
 
   public SchemaException(Object schema, String message, Throwable cause) {
     super(message, cause);
@@ -43,7 +43,7 @@ public class SchemaException extends VertxException {
   @Override
   public String toString() {
     return "SchemaException{" +
-      "message=\'" + getMessage() + "\'" +
+      "message='" + getMessage() + "'" +
       ", schema=" + schema +
       '}';
   }

--- a/src/main/java/io/vertx/json/schema/common/AllOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/AllOfValidatorFactory.java
@@ -30,7 +30,7 @@ public class AllOfValidatorFactory extends BaseCombinatorsValidatorFactory {
     return "allOf";
   }
 
-  class AllOfValidator extends BaseCombinatorsValidator {
+  static class AllOfValidator extends BaseCombinatorsValidator {
 
     public AllOfValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/common/AnyOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/AnyOfValidatorFactory.java
@@ -36,7 +36,7 @@ public class AnyOfValidatorFactory extends BaseCombinatorsValidatorFactory {
     return "anyOf";
   }
 
-  class AnyOfValidator extends BaseCombinatorsValidator {
+  static class AnyOfValidator extends BaseCombinatorsValidator {
 
     public AnyOfValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/common/BaseCombinatorsValidator.java
+++ b/src/main/java/io/vertx/json/schema/common/BaseCombinatorsValidator.java
@@ -34,7 +34,7 @@ public abstract class BaseCombinatorsValidator extends BaseMutableStateValidator
   }
 
   void setSchemas(List<SchemaInternal> schemas) {
-    this.schemas = schemas.toArray(new SchemaInternal[schemas.size()]);
+    this.schemas = schemas.toArray(new SchemaInternal[0]);
     Arrays.sort(this.schemas, ValidatorPriority.COMPARATOR);
     this.initializeIsSync();
   }

--- a/src/main/java/io/vertx/json/schema/common/BaseFormatValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/BaseFormatValidatorFactory.java
@@ -88,9 +88,9 @@ public abstract class BaseFormatValidatorFactory implements ValidatorFactory {
     }
   };
 
-  class FormatValidator extends BaseSyncValidator {
+  static class FormatValidator extends BaseSyncValidator {
 
-    Predicate<String> validator;
+    final Predicate<String> validator;
 
     public FormatValidator(Predicate<String> validator) {
       this.validator = validator;
@@ -106,8 +106,8 @@ public abstract class BaseFormatValidatorFactory implements ValidatorFactory {
     }
   }
 
-  protected Map<String, Predicate<String>> formats;
-  protected List<String> ignoringFormats;
+  protected final Map<String, Predicate<String>> formats;
+  protected final List<String> ignoringFormats;
 
   public BaseFormatValidatorFactory() {
     this.formats = initFormatsMap();

--- a/src/main/java/io/vertx/json/schema/common/ConstValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ConstValidatorFactory.java
@@ -28,7 +28,7 @@ public class ConstValidatorFactory implements ValidatorFactory {
     return schema.containsKey("const");
   }
 
-  public class ConstValidator extends BaseSyncValidator {
+  public static class ConstValidator extends BaseSyncValidator {
 
     private final Object allowedValue;
 

--- a/src/main/java/io/vertx/json/schema/common/DefinitionsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/DefinitionsValidatorFactory.java
@@ -29,9 +29,7 @@ public class DefinitionsValidatorFactory implements ValidatorFactory {
     try {
       JsonObject definitions = schema.getJsonObject(this.definitionsKey);
       JsonPointer basePointer = scope.append(this.definitionsKey);
-      definitions.forEach(e -> {
-        parser.parse((e.getValue() instanceof Map) ? new JsonObject((Map<String, Object>) e.getValue()) : e.getValue(), basePointer.copy().append(e.getKey()), null);
-      });
+      definitions.forEach(e -> parser.parse((e.getValue() instanceof Map) ? new JsonObject((Map<String, Object>) e.getValue()) : e.getValue(), basePointer.copy().append(e.getKey()), null));
       return null;
     } catch (ClassCastException e) {
       throw new SchemaException(schema, "Wrong type for " + this.definitionsKey + " keyword", e);

--- a/src/main/java/io/vertx/json/schema/common/EnumValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/EnumValidatorFactory.java
@@ -49,7 +49,7 @@ public class EnumValidatorFactory implements ValidatorFactory {
     return schema.containsKey("enum");
   }
 
-  public class EnumValidator extends BaseSyncValidator {
+  public static class EnumValidator extends BaseSyncValidator {
     private final Object[] allowedValues;
 
     public EnumValidator(Set allowedValues) {
@@ -63,8 +63,8 @@ public class EnumValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
-      for (int i = 0; i < allowedValues.length; i++) {
-        if (ComparisonUtils.equalsNumberSafe(allowedValues[i], in))
+      for (Object allowedValue : allowedValues) {
+        if (ComparisonUtils.equalsNumberSafe(allowedValue, in))
           return;
       }
       throw ValidationException.createException("Input doesn't match one of allowed values of enum: " + Arrays.toString(allowedValues), "enum", in);

--- a/src/main/java/io/vertx/json/schema/common/FalseSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/FalseSchema.java
@@ -25,7 +25,7 @@ public class FalseSchema implements SchemaInternal {
     return FalseSchemaHolder.INSTANCE;
   }
 
-  MutableStateValidator parent;
+  final MutableStateValidator parent;
 
   public FalseSchema(MutableStateValidator parent) {
     this.parent = parent;

--- a/src/main/java/io/vertx/json/schema/common/FutureUtils.java
+++ b/src/main/java/io/vertx/json/schema/common/FutureUtils.java
@@ -26,8 +26,8 @@ public class FutureUtils {
     final AtomicBoolean atLeastOneOk = new AtomicBoolean(false);
     final AtomicReference<T> result = new AtomicReference<>();
     final int len = results.size();
-    for (int i = 0; i < len; i++) {
-      results.get(i).onComplete(ar -> {
+    for (Future<T> tFuture : results) {
+      tFuture.onComplete(ar -> {
         int p = processed.incrementAndGet();
         if (ar.succeeded()) {
           if (atLeastOneOk.get())

--- a/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
@@ -13,7 +13,6 @@ package io.vertx.json.schema.common;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.ValidationException;
 

--- a/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
@@ -48,7 +48,7 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
         List<?> arr = (List<?>) in;
         for (int i = 0; i < arr.size(); i++) {
           context.markEvaluatedItem(i);
-          schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+          schema.validateSync(context.lowerLevelContext(), arr.get(i));
         }
       }
     }
@@ -64,7 +64,7 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
         List<Future> futs = new ArrayList<>();
         for (int i = 0; i < arr.size(); i++) {
           context.markEvaluatedItem(i);
-          Future<Void> f = schema.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+          Future<Void> f = schema.validateAsync(context.lowerLevelContext(), arr.get(i));
           if (f.isComplete()) {
             if (f.failed()) return Future.failedFuture(f.cause());
           } else {
@@ -91,12 +91,11 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
       List<Future> futures = new ArrayList<>();
       List<?> arr = (List<?>) in;
       for (Object o : arr) {
-        Object valToDefault = JsonUtil.wrapJsonValue(o);
         if (schema.isSync()) {
-          schema.getOrApplyDefaultSync(valToDefault);
+          schema.getOrApplyDefaultSync(o);
         } else {
           futures.add(
-            schema.getOrApplyDefaultAsync(valToDefault)
+            schema.getOrApplyDefaultAsync(o)
           );
         }
       }

--- a/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/ItemsValidatorFactory.java
@@ -32,7 +32,7 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
     return "items";
   }
 
-  class ItemsValidator extends BaseSingleSchemaValidator implements DefaultApplier {
+  static class ItemsValidator extends BaseSingleSchemaValidator implements DefaultApplier {
 
     public ItemsValidator(MutableStateValidator parent) {
       super(parent);
@@ -90,8 +90,8 @@ public class ItemsValidatorFactory extends BaseSingleSchemaValidatorFactory {
 
       List<Future> futures = new ArrayList<>();
       List<?> arr = (List<?>) in;
-      for (int i = 0; i < arr.size(); i++) {
-        Object valToDefault = JsonUtil.wrapJsonValue(arr.get(i));
+      for (Object o : arr) {
+        Object valToDefault = JsonUtil.wrapJsonValue(o);
         if (schema.isSync()) {
           schema.getOrApplyDefaultSync(valToDefault);
         } else {

--- a/src/main/java/io/vertx/json/schema/common/JsonSchemaType.java
+++ b/src/main/java/io/vertx/json/schema/common/JsonSchemaType.java
@@ -13,14 +13,16 @@ package io.vertx.json.schema.common;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
 public enum JsonSchemaType {
   NULL(Objects::isNull),
   BOOLEAN(o -> o instanceof Boolean),
-  OBJECT(o -> o instanceof JsonObject),
-  ARRAY(o -> o instanceof JsonArray),
+  OBJECT(o -> o instanceof Map || o instanceof JsonObject),
+  ARRAY(o -> o instanceof List || o instanceof JsonArray),
   NUMBER(o -> o instanceof Number),
   NUMBER_DECIMAL(o -> o instanceof Double || o instanceof Float),
   INTEGER(o -> o instanceof Long || o instanceof Integer),

--- a/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
@@ -39,7 +39,7 @@ public class MaxItemsValidatorFactory implements ValidatorFactory {
     return schema.containsKey("maxItems");
   }
 
-  public class MaxItemsValidator extends BaseSyncValidator {
+  public static class MaxItemsValidator extends BaseSyncValidator {
     private final int maximum;
 
     public MaxItemsValidator(int maximum) {

--- a/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxItemsValidatorFactory.java
@@ -16,6 +16,8 @@ import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
+import java.util.List;
+
 public class MaxItemsValidatorFactory implements ValidatorFactory {
 
   @Override
@@ -46,9 +48,13 @@ public class MaxItemsValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
+      final Object orig = in;
       if (in instanceof JsonArray) {
-        if (((JsonArray) in).size() > maximum) {
-          throw ValidationException.createException("provided array should have size <= " + maximum, "maxItems", in);
+        in = ((JsonArray) in).getList();
+      }
+      if (in instanceof List) {
+        if (((List<?>) in).size() > maximum) {
+          throw ValidationException.createException("provided array should have size <= " + maximum, "maxItems", orig);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MaxLengthValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxLengthValidatorFactory.java
@@ -36,7 +36,7 @@ public class MaxLengthValidatorFactory implements ValidatorFactory {
     return schema.containsKey("maxLength");
   }
 
-  public class MaxLengthValidator extends BaseSyncValidator {
+  public static class MaxLengthValidator extends BaseSyncValidator {
     private final int maximum;
 
     public MaxLengthValidator(int maximum) {

--- a/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
@@ -38,7 +38,7 @@ public class MaxPropertiesValidatorFactory implements ValidatorFactory {
     return schema.containsKey("maxProperties");
   }
 
-  public class MaxPropertiesValidator extends BaseSyncValidator {
+  public static class MaxPropertiesValidator extends BaseSyncValidator {
     private final int maximum;
 
     public MaxPropertiesValidator(int maximum) {

--- a/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MaxPropertiesValidatorFactory.java
@@ -15,6 +15,8 @@ import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
+import java.util.Map;
+
 public class MaxPropertiesValidatorFactory implements ValidatorFactory {
 
   @Override
@@ -45,9 +47,14 @@ public class MaxPropertiesValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
+      final Object orig = in;
+      // attempt to handle JsonObject as Map
       if (in instanceof JsonObject) {
-        if (((JsonObject) in).size() > maximum) {
-          throw ValidationException.createException("provided object should have size <= " + maximum, "maxProperties", in);
+        in = ((JsonObject) in).getMap();
+      }
+      if (in instanceof Map) {
+        if (((Map) in).size() > maximum) {
+          throw ValidationException.createException("provided object should have size <= " + maximum, "maxProperties", orig);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
@@ -39,7 +39,7 @@ public class MinItemsValidatorFactory implements ValidatorFactory {
     return schema.containsKey("minItems");
   }
 
-  public class MinItemsValidator extends BaseSyncValidator {
+  public static class MinItemsValidator extends BaseSyncValidator {
     private final int minimum;
 
     public MinItemsValidator(int minimum) {

--- a/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinItemsValidatorFactory.java
@@ -16,6 +16,8 @@ import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
+import java.util.List;
+
 public class MinItemsValidatorFactory implements ValidatorFactory {
 
   @Override
@@ -46,9 +48,13 @@ public class MinItemsValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
+      final Object orig = in;
       if (in instanceof JsonArray) {
-        if (((JsonArray) in).size() < minimum) {
-          throw ValidationException.createException("provided array should have size >= " + minimum, "minItems", in);
+        in = ((JsonArray) in).getList();
+      }
+      if (in instanceof List) {
+        if (((List<?>) in).size() < minimum) {
+          throw ValidationException.createException("provided array should have size >= " + minimum, "minItems", orig);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinLengthValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinLengthValidatorFactory.java
@@ -36,7 +36,7 @@ public class MinLengthValidatorFactory implements ValidatorFactory {
     return schema.containsKey("minLength");
   }
 
-  public class MinLengthValidator extends BaseSyncValidator {
+  public static class MinLengthValidator extends BaseSyncValidator {
     private final int minimum;
 
     public MinLengthValidator(int minimum) {

--- a/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
@@ -15,6 +15,8 @@ import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
+import java.util.Map;
+
 public class MinPropertiesValidatorFactory implements ValidatorFactory {
 
   @Override
@@ -45,9 +47,14 @@ public class MinPropertiesValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
+      final Object orig = in;
+      // attempt to handle JsonObject as Map
       if (in instanceof JsonObject) {
-        if (((JsonObject) in).size() < minimum) {
-          throw ValidationException.createException("provided object should have size >= " + minimum, "minProperties", in);
+        in = ((JsonObject) in).getMap();
+      }
+      if (in instanceof Map) {
+        if (((Map) in).size() < minimum) {
+          throw ValidationException.createException("provided object should have size >= " + minimum, "minProperties", orig);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MinPropertiesValidatorFactory.java
@@ -38,7 +38,7 @@ public class MinPropertiesValidatorFactory implements ValidatorFactory {
     return schema.containsKey("minProperties");
   }
 
-  public class MinPropertiesValidator extends BaseSyncValidator {
+  public static class MinPropertiesValidator extends BaseSyncValidator {
     private final int minimum;
 
     public MinPropertiesValidator(int minimum) {

--- a/src/main/java/io/vertx/json/schema/common/MultipleOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/MultipleOfValidatorFactory.java
@@ -34,7 +34,7 @@ public class MultipleOfValidatorFactory implements ValidatorFactory {
     return schema.containsKey("multipleOf");
   }
 
-  class MultipleOfValidator extends BaseSyncValidator {
+  static class MultipleOfValidator extends BaseSyncValidator {
     private final double multipleOf;
 
     public MultipleOfValidator(double multipleOf) {

--- a/src/main/java/io/vertx/json/schema/common/NotValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/NotValidatorFactory.java
@@ -26,7 +26,7 @@ public class NotValidatorFactory extends BaseSingleSchemaValidatorFactory {
     return "not";
   }
 
-  class NotValidator extends BaseSingleSchemaValidator {
+  static class NotValidator extends BaseSingleSchemaValidator {
 
     public NotValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/common/OneOfValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/OneOfValidatorFactory.java
@@ -31,7 +31,7 @@ public class OneOfValidatorFactory extends BaseCombinatorsValidatorFactory {
     return "oneOf";
   }
 
-  class OneOfValidator extends BaseCombinatorsValidator {
+  static class OneOfValidator extends BaseCombinatorsValidator {
 
     public OneOfValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/common/PatternValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PatternValidatorFactory.java
@@ -40,7 +40,7 @@ public class PatternValidatorFactory implements ValidatorFactory {
     return schema.containsKey("pattern");
   }
 
-  public class PatternValidator extends BaseSyncValidator {
+  public static class PatternValidator extends BaseSyncValidator {
     private final Pattern pattern;
 
     public PatternValidator(Pattern pattern) {

--- a/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
@@ -12,7 +12,6 @@ package io.vertx.json.schema.common;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;

--- a/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
@@ -13,7 +13,6 @@ package io.vertx.json.schema.common;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.Schema;
 import io.vertx.json.schema.SchemaException;

--- a/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/PropertiesValidatorFactory.java
@@ -166,12 +166,12 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
             context.markEvaluatedProperty(key);
             if (s.isSync()) {
               try {
-                s.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+                s.validateSync(context.lowerLevelContext(), obj.get(key));
               } catch (ValidationException e) {
                 return Future.failedFuture(e);
               }
             } else {
-              futs.add(s.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key))));
+              futs.add(s.validateAsync(context.lowerLevelContext(), obj.get(key)));
             }
             found = true;
           }
@@ -182,12 +182,12 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
                 context.markEvaluatedProperty(key);
                 if (s.isSync()) {
                   try {
-                    s.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+                    s.validateSync(context.lowerLevelContext(), obj.get(key));
                   } catch (ValidationException e) {
                     return Future.failedFuture(e);
                   }
                 } else {
-                  futs.add(s.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key))));
+                  futs.add(s.validateAsync(context.lowerLevelContext(), obj.get(key)));
                 }
                 found = true;
               }
@@ -199,13 +199,13 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
                 context.markEvaluatedProperty(key);
                 if (additionalPropertiesSchema.isSync()) {
                   try {
-                    additionalPropertiesSchema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+                    additionalPropertiesSchema.validateSync(context.lowerLevelContext(), obj.get(key));
                   } catch (ValidationException e) {
                     return fillAdditionalPropertyException(e, orig);
                   }
                 } else {
                   futs.add(additionalPropertiesSchema
-                    .validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)))
+                    .validateAsync(context.lowerLevelContext(), obj.get(key))
                     .recover(t -> fillAdditionalPropertyException(t, orig))
                   );
                 }
@@ -234,7 +234,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
           if (properties != null && properties.containsKey(key)) {
             SchemaInternal s = properties.get(key);
             context.markEvaluatedProperty(key);
-            s.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+            s.validateSync(context.lowerLevelContext(), obj.get(key));
             found = true;
           }
           if (patternProperties != null) {
@@ -242,7 +242,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
               if (patternProperty.getKey().matcher(key).find()) {
                 SchemaInternal s = patternProperty.getValue();
                 context.markEvaluatedProperty(key);
-                s.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+                s.validateSync(context.lowerLevelContext(), obj.get(key));
                 found = true;
               }
             }
@@ -251,7 +251,7 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
             if (allowAdditionalProperties) {
               if (additionalPropertiesSchema != null) {
                 context.markEvaluatedProperty(key);
-                additionalPropertiesSchema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)));
+                additionalPropertiesSchema.validateSync(context.lowerLevelContext(), obj.get(key));
               }
             } else {
               throw createException("provided object should not contain additional properties", "additionalProperties", orig);
@@ -295,10 +295,10 @@ public class PropertiesValidatorFactory implements ValidatorFactory {
           }
         } else {
           if (schema.isSync()) {
-            schema.getOrApplyDefaultSync(JsonUtil.wrapJsonValue(obj.get(key)));
+            schema.getOrApplyDefaultSync(obj.get(key));
           } else {
             futs.add(
-              schema.getOrApplyDefaultAsync(JsonUtil.wrapJsonValue(obj.get(key)))
+              schema.getOrApplyDefaultAsync(obj.get(key))
             );
           }
         }

--- a/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
@@ -17,6 +17,7 @@ import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static io.vertx.json.schema.ValidationException.createException;
@@ -49,11 +50,16 @@ public class RequiredValidatorFactory implements ValidatorFactory {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException {
+      final Object orig = in;
+      // attempt to handle JsonObject as Map
       if (in instanceof JsonObject) {
-        JsonObject obj = (JsonObject) in;
+        in = ((JsonObject) in).getMap();
+      }
+      if (in instanceof Map) {
+        Map<String, ?> obj = (Map) in;
         for (String k : requiredKeys) {
           if (!obj.containsKey(k))
-            throw createException("provided object should contain property " + k, "required", in);
+            throw createException("provided object should contain property " + k, "required", orig);
         }
       }
     }

--- a/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/RequiredValidatorFactory.java
@@ -41,7 +41,7 @@ public class RequiredValidatorFactory implements ValidatorFactory {
     return schema.containsKey("required");
   }
 
-  public class RequiredValidator extends BaseSyncValidator {
+  public static class RequiredValidator extends BaseSyncValidator {
     private final Set<String> requiredKeys;
 
     public RequiredValidator(Set<String> requiredKeys) {

--- a/src/main/java/io/vertx/json/schema/common/RouterNodeJsonPointerIterator.java
+++ b/src/main/java/io/vertx/json/schema/common/RouterNodeJsonPointerIterator.java
@@ -40,7 +40,7 @@ class RouterNodeJsonPointerIterator implements JsonPointerIterator {
   @Override
   public Object getObjectParameter(Object value, String key, boolean createOnMissing) {
     if (isObject(value)) {
-      if (!objectContainsKey(value, key) && createOnMissing) {
+      if (!objectContainsKey(value, key)) {
         if (createOnMissing) {
           RouterNode node = new RouterNode();
           ((RouterNode) value).getChilds().put(key, node);

--- a/src/main/java/io/vertx/json/schema/common/SchemaParserInternal.java
+++ b/src/main/java/io/vertx/json/schema/common/SchemaParserInternal.java
@@ -63,8 +63,6 @@ public interface SchemaParserInternal extends SchemaParser {
     return parseFromString(unparsedJson, schemaPointer, null);
   }
 
-  ;
-
   default SchemaInternal parseFromString(String unparsedJson, URI scope, MutableStateValidator parent) {
     return this.parseFromString(unparsedJson, JsonPointer.fromURI(scope), parent);
   }

--- a/src/main/java/io/vertx/json/schema/common/TrueSchema.java
+++ b/src/main/java/io/vertx/json/schema/common/TrueSchema.java
@@ -25,7 +25,7 @@ public class TrueSchema implements SchemaInternal {
     return TrueSchemaHolder.INSTANCE;
   }
 
-  MutableStateValidator parent;
+  final MutableStateValidator parent;
 
   public TrueSchema(MutableStateValidator parent) {
     this.parent = parent;

--- a/src/main/java/io/vertx/json/schema/common/UniqueItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/common/UniqueItemsValidatorFactory.java
@@ -18,6 +18,7 @@ import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 
 import java.util.HashSet;
+import java.util.List;
 
 import static io.vertx.json.schema.ValidationException.createException;
 
@@ -26,10 +27,14 @@ public class UniqueItemsValidatorFactory implements ValidatorFactory {
   private final static BaseSyncValidator UNIQUE_VALIDATOR = new BaseSyncValidator() {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
+      final Object orig = in;
       if (in instanceof JsonArray) {
-        JsonArray arr = (JsonArray) in;
-        if (new HashSet(arr.getList()).size() != arr.size())
-          throw createException("array elements must be unique", "uniqueItems", in);
+        in = ((JsonArray) in).getList();
+      }
+      if (in instanceof List) {
+        List<?> arr = (List<?>) in;
+        if (new HashSet<>(arr).size() != arr.size())
+          throw createException("array elements must be unique", "uniqueItems", orig);
       }
     }
   };

--- a/src/main/java/io/vertx/json/schema/common/ValidatorPriority.java
+++ b/src/main/java/io/vertx/json/schema/common/ValidatorPriority.java
@@ -26,7 +26,7 @@ public enum ValidatorPriority {
     this.priority = value;
   }
 
-  public static Comparator<PriorityGetter> COMPARATOR = (v1, v2) -> {
+  public static final Comparator<PriorityGetter> COMPARATOR = (v1, v2) -> {
     int res = v1.getPriority().priority.compareTo(v2.getPriority().priority);
     if (res == 0) return (v1.equals(v2)) ? 0 : +1; // Comparator need to be consistent with equals generic
     else return res;

--- a/src/main/java/io/vertx/json/schema/common/dsl/Keyword.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/Keyword.java
@@ -14,8 +14,8 @@ import java.util.function.Supplier;
 
 public class Keyword {
 
-  private String keyword;
-  private Supplier<Object> value;
+  private final String keyword;
+  private final Supplier<Object> value;
 
   public Keyword(String keyword, Supplier<Object> value) {
     this.keyword = keyword;

--- a/src/main/java/io/vertx/json/schema/common/dsl/ObjectSchemaBuilder.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/ObjectSchemaBuilder.java
@@ -18,9 +18,9 @@ import java.util.regex.Pattern;
 
 public final class ObjectSchemaBuilder extends SchemaBuilder<ObjectSchemaBuilder, ObjectKeyword> {
 
-  Map<String, SchemaBuilder> properties;
-  Map<Pattern, SchemaBuilder> patternProperties;
-  Set<String> requiredProperties;
+  final Map<String, SchemaBuilder> properties;
+  final Map<Pattern, SchemaBuilder> patternProperties;
+  final Set<String> requiredProperties;
 
   ObjectSchemaBuilder() {
     super(SchemaType.OBJECT);

--- a/src/main/java/io/vertx/json/schema/common/dsl/SchemaBuilder.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/SchemaBuilder.java
@@ -32,9 +32,9 @@ import java.util.function.Supplier;
 public abstract class SchemaBuilder<T extends SchemaBuilder<?, ?>, K extends Keyword> {
 
   protected SchemaType type;
-  protected Map<String, Supplier<Object>> keywords;
+  protected final Map<String, Supplier<Object>> keywords;
   protected URI id;
-  T self;
+  final T self;
 
   @SuppressWarnings("unchecked")
   public SchemaBuilder(SchemaType type) {
@@ -55,12 +55,6 @@ public abstract class SchemaBuilder<T extends SchemaBuilder<?, ?>, K extends Key
   @Fluent
   public T id(JsonPointer id) {
     this.id = id.toURI();
-    return self;
-  }
-
-  @Fluent
-  public T with(K keyword) {
-    this.keywords.put(keyword.getKeyword(), keyword.getValueSupplier());
     return self;
   }
 

--- a/src/main/java/io/vertx/json/schema/common/dsl/SchemaType.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/SchemaType.java
@@ -18,7 +18,7 @@ public enum SchemaType {
   ARRAY("array"),
   OBJECT("object");
 
-  private String name;
+  private final String name;
 
   SchemaType(String name) {
     this.name = name;

--- a/src/main/java/io/vertx/json/schema/common/dsl/TupleSchemaBuilder.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/TupleSchemaBuilder.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 public final class TupleSchemaBuilder extends SchemaBuilder<TupleSchemaBuilder, ArrayKeyword> {
 
   // For items keyword as list of schemas
-  private List<SchemaBuilder> itemList;
+  private final List<SchemaBuilder> itemList;
   private SchemaBuilder additionalItems;
 
   TupleSchemaBuilder() {

--- a/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
@@ -110,7 +110,7 @@ public class ContainsValidatorFactory implements ValidatorFactory {
         List<?> arr = (List<?>) in;
         for (int i = 0; i < arr.size(); i++) {
           try {
-            schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+            schema.validateSync(context.lowerLevelContext(), arr.get(i));
             context.markEvaluatedItem(i);
             matches++;
           } catch (ValidationException e) {

--- a/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
@@ -14,7 +14,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.SchemaException;

--- a/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/ContainsValidatorFactory.java
@@ -46,7 +46,7 @@ public class ContainsValidatorFactory implements ValidatorFactory {
     return schema.containsKey("contains");
   }
 
-  class BoundedContainsValidator extends BaseSingleSchemaValidator {
+  static class BoundedContainsValidator extends BaseSingleSchemaValidator {
 
     private final int min;
     private final Integer max;

--- a/src/main/java/io/vertx/json/schema/draft201909/DependentRequiredValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/DependentRequiredValidatorFactory.java
@@ -18,7 +18,6 @@ import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.*;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +44,7 @@ public class DependentRequiredValidatorFactory implements ValidatorFactory {
     return schema.containsKey("dependentRequired");
   }
 
-  class DependentRequiredValidator extends BaseSyncValidator {
+  static class DependentRequiredValidator extends BaseSyncValidator {
 
     public final Map<String, Set<String>> keyDeps;
 

--- a/src/main/java/io/vertx/json/schema/draft201909/DependentSchemasValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/DependentSchemasValidatorFactory.java
@@ -66,13 +66,17 @@ public class DependentSchemasValidatorFactory implements ValidatorFactory {
     @Override
     public Future<Void> validateAsync(ValidatorContext context, Object in) {
       if (isSync()) return validateSyncAsAsync(context, in);
+      final Object orig = in;
       if (in instanceof JsonObject) {
-        JsonObject obj = (JsonObject) in;
+        in = ((JsonObject) in).getMap();
+      }
+      if (in instanceof Map) {
+        Map<String, ?> obj = (Map) in;
         List<Future> futs = keySchemaDeps
           .entrySet()
           .stream()
           .filter(e -> obj.containsKey(e.getKey()))
-          .map(e -> e.getValue().validateAsync(context, in))
+          .map(e -> e.getValue().validateAsync(context, orig))
           .collect(Collectors.toList());
         if (futs.isEmpty()) return Future.succeededFuture();
         else return CompositeFuture.all(futs).mapEmpty();
@@ -82,13 +86,17 @@ public class DependentSchemasValidatorFactory implements ValidatorFactory {
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
+      final Object orig = in;
       if (in instanceof JsonObject) {
-        JsonObject obj = (JsonObject) in;
+        in = ((JsonObject) in).getMap();
+      }
+      if (in instanceof Map) {
+        Map<String, ?> obj = (Map) in;
         keySchemaDeps
           .entrySet()
           .stream()
           .filter(e -> obj.containsKey(e.getKey()))
-          .forEach(e -> e.getValue().validateSync(context, in));
+          .forEach(e -> e.getValue().validateSync(context, orig));
       }
     }
 

--- a/src/main/java/io/vertx/json/schema/draft201909/DependentSchemasValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/DependentSchemasValidatorFactory.java
@@ -50,7 +50,7 @@ public class DependentSchemasValidatorFactory implements ValidatorFactory {
     return schema.containsKey("dependentSchemas");
   }
 
-  class DependentSchemasValidator extends BaseMutableStateValidator {
+  static class DependentSchemasValidator extends BaseMutableStateValidator {
 
     Map<String, SchemaInternal> keySchemaDeps;
 

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
@@ -22,7 +22,6 @@ import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.*;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -54,7 +53,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
     return schema.containsKey("unevaluatedItems");
   }
 
-  class SchemedUnevaluatedItemsValidator extends BaseSingleSchemaValidator {
+  static class SchemedUnevaluatedItemsValidator extends BaseSingleSchemaValidator {
 
     public SchemedUnevaluatedItemsValidator(MutableStateValidator parent) {
       super(parent);
@@ -118,7 +117,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
     }
   }
 
-  class NoUnevaluatedItemsValidator extends BaseSyncValidator {
+  static class NoUnevaluatedItemsValidator extends BaseSyncValidator {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
@@ -73,7 +73,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
         return CompositeFuture.all(
           unevaluatedItems
             .stream()
-            .map(index -> schema.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(array.get(index))))
+            .map(index -> schema.validateAsync(context.lowerLevelContext(), array.get(index)))
             .collect(Collectors.toList())
         )
           .recover(t -> Future.failedFuture(ValidationException.createException(
@@ -99,7 +99,7 @@ public class UnevaluatedItemsValidatorFactory implements ValidatorFactory {
         Set<Integer> unevaluatedProperties = computeUnevaluatedItems(context, array);
 
         unevaluatedProperties.forEach(index ->
-          schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(array.get(index)))
+          schema.validateSync(context.lowerLevelContext(), array.get(index))
         );
       }
     }

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedItemsValidatorFactory.java
@@ -14,7 +14,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.SchemaException;

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
@@ -12,7 +12,6 @@ package io.vertx.json.schema.draft201909;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
@@ -21,7 +20,6 @@ import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.*;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,7 +52,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
     return schema.containsKey("unevaluatedProperties");
   }
 
-  class SchemedUnevaluatedPropertiesValidator extends BaseSingleSchemaValidator {
+  static class SchemedUnevaluatedPropertiesValidator extends BaseSingleSchemaValidator {
 
     public SchemedUnevaluatedPropertiesValidator(MutableStateValidator parent) {
       super(parent);
@@ -119,7 +117,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
     }
   }
 
-  class NoUnevaluatedPropertiesValidator extends BaseSyncValidator {
+  static class NoUnevaluatedPropertiesValidator extends BaseSyncValidator {
 
     @Override
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
@@ -72,7 +72,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
         return CompositeFuture.all(
           unevaluatedItems
             .stream()
-            .map(key -> schema.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key))))
+            .map(key -> schema.validateAsync(context.lowerLevelContext(), obj.get(key)))
             .collect(Collectors.toList())
         )
           .recover(t -> Future.failedFuture(ValidationException.createException(
@@ -99,7 +99,7 @@ public class UnevaluatedPropertiesValidatorFactory implements ValidatorFactory {
         Set<String> unevaluatedProperties = computeUnevaluatedProperties(context, obj);
 
         unevaluatedProperties.forEach(key ->
-          schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(obj.get(key)))
+          schema.validateSync(context.lowerLevelContext(), obj.get(key))
         );
       }
     }

--- a/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/UnevaluatedPropertiesValidatorFactory.java
@@ -13,7 +13,6 @@ package io.vertx.json.schema.draft201909;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.SchemaException;

--- a/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
@@ -37,7 +37,7 @@ public class ContainsValidatorFactory extends BaseSingleSchemaValidatorFactory {
     return "contains";
   }
 
-  class ContainsValidator extends BaseSingleSchemaValidator {
+  static class ContainsValidator extends BaseSingleSchemaValidator {
 
     public ContainsValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
@@ -13,6 +13,7 @@ package io.vertx.json.schema.draft7;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.BaseSingleSchemaValidator;
@@ -20,6 +21,7 @@ import io.vertx.json.schema.common.BaseSingleSchemaValidatorFactory;
 import io.vertx.json.schema.common.MutableStateValidator;
 import io.vertx.json.schema.common.ValidatorContext;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,15 +46,19 @@ public class ContainsValidatorFactory extends BaseSingleSchemaValidatorFactory {
     @Override
     public Future<Void> validateAsync(ValidatorContext context, Object in) {
       if (isSync()) return validateSyncAsAsync(context, in);
+      final Object orig = in;
       if (in instanceof JsonArray) {
-        JsonArray arr = (JsonArray) in;
+        in = ((JsonArray) in).getList();
+      }
+      if (in instanceof List) {
+        List<?> arr = (List<?>) in;
         if (arr.isEmpty())
-          return Future.failedFuture(ValidationException.createException("provided array should not be empty", "contains", in));
+          return Future.failedFuture(ValidationException.createException("provided array should not be empty", "contains", orig));
         else
           return CompositeFuture.any(
             arr
               .stream()
-              .map(i -> schema.validateAsync(context.lowerLevelContext(), in))
+              .map(i -> schema.validateAsync(context.lowerLevelContext(), orig))
               .collect(Collectors.toList())
           ).compose(
             cf -> {
@@ -64,7 +70,7 @@ public class ContainsValidatorFactory extends BaseSingleSchemaValidatorFactory {
                 });
               return Future.succeededFuture();
             },
-            err -> Future.failedFuture(ValidationException.createException("provided array doesn't contain an element matching the contains schema", "contains", in, err))
+            err -> Future.failedFuture(ValidationException.createException("provided array doesn't contain an element matching the contains schema", "contains", orig, err))
           );
       } else return Future.succeededFuture();
     }
@@ -73,18 +79,22 @@ public class ContainsValidatorFactory extends BaseSingleSchemaValidatorFactory {
     public void validateSync(ValidatorContext context, Object in) throws ValidationException, NoSyncValidationException {
       this.checkSync();
       ValidationException t = null;
+      final Object orig = in;
       if (in instanceof JsonArray) {
-        JsonArray arr = (JsonArray) in;
+        in = ((JsonArray) in).getList();
+      }
+      if (in instanceof List) {
+        List<?> arr = (List<?>) in;
         for (int i = 0; i < arr.size(); i++) {
           try {
-            schema.validateSync(context.lowerLevelContext(), arr.getValue(i));
+            schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
             context.markEvaluatedItem(i);
             return;
           } catch (ValidationException e) {
             t = e;
           }
         }
-        throw ValidationException.createException("provided array doesn't contain an element matching the contains schema", "contains", in, t);
+        throw ValidationException.createException("provided array doesn't contain an element matching the contains schema", "contains", orig, t);
       }
     }
 

--- a/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
@@ -13,7 +13,6 @@ package io.vertx.json.schema.draft7;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.BaseSingleSchemaValidator;

--- a/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ContainsValidatorFactory.java
@@ -87,7 +87,7 @@ public class ContainsValidatorFactory extends BaseSingleSchemaValidatorFactory {
         List<?> arr = (List<?>) in;
         for (int i = 0; i < arr.size(); i++) {
           try {
-            schema.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+            schema.validateSync(context.lowerLevelContext(), arr.get(i));
             context.markEvaluatedItem(i);
             return;
           } catch (ValidationException e) {

--- a/src/main/java/io/vertx/json/schema/draft7/DependenciesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/DependenciesValidatorFactory.java
@@ -20,10 +20,7 @@ import io.vertx.json.schema.SchemaException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.json.schema.common.*;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class DependenciesValidatorFactory implements ValidatorFactory {
@@ -42,7 +39,7 @@ public class DependenciesValidatorFactory implements ValidatorFactory {
           keySchemaDeps.put(entry.getKey(), parser.parse((entry.getValue() instanceof Map) ? new JsonObject((Map<String, Object>) entry.getValue()) : entry.getValue(), baseScope.copy().append(entry.getKey()), validator));
         } else {
           if (!((List) entry.getValue()).isEmpty())
-            keyDeps.put(entry.getKey(), ((List<String>) entry.getValue()).stream().collect(Collectors.toSet()));
+            keyDeps.put(entry.getKey(), new HashSet<>(((List<String>) entry.getValue())));
         }
       }
       validator.configure(keyDeps, keySchemaDeps);
@@ -59,7 +56,7 @@ public class DependenciesValidatorFactory implements ValidatorFactory {
     return schema.containsKey("dependencies");
   }
 
-  class DependenciesValidator extends BaseMutableStateValidator {
+  static class DependenciesValidator extends BaseMutableStateValidator {
 
     Map<String, Set<String>> keyDeps;
     Map<String, SchemaInternal> keySchemaDeps;

--- a/src/main/java/io/vertx/json/schema/draft7/IfThenElseValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/IfThenElseValidatorFactory.java
@@ -45,7 +45,7 @@ public class IfThenElseValidatorFactory implements ValidatorFactory {
     return schema.containsKey("if") && (schema.containsKey("then") || schema.containsKey("else"));
   }
 
-  class IfThenElseValidator extends BaseMutableStateValidator {
+  static class IfThenElseValidator extends BaseMutableStateValidator {
 
     private SchemaInternal condition;
     private SchemaInternal thenBranch;

--- a/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
@@ -42,9 +42,9 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
           parsedSchemas.add(i, parser.parse(itemsList.getValue(i), baseScope.copy().append(Integer.toString(i)), validator));
         }
         if (schema.containsKey("additionalItems"))
-          validator.configure(parsedSchemas.toArray(new SchemaInternal[parsedSchemas.size()]), parser.parse(schema.getValue("additionalItems"), scope.copy().append("additionalItems"), validator));
+          validator.configure(parsedSchemas.toArray(new SchemaInternal[0]), parser.parse(schema.getValue("additionalItems"), scope.copy().append("additionalItems"), validator));
         else
-          validator.configure(parsedSchemas.toArray(new SchemaInternal[parsedSchemas.size()]), null);
+          validator.configure(parsedSchemas.toArray(new SchemaInternal[0]), null);
         return validator;
       } catch (NullPointerException e) {
         throw new SchemaException(schema, "Null items keyword", e);
@@ -54,7 +54,7 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
     }
   }
 
-  class ItemByItemValidator extends BaseMutableStateValidator implements DefaultApplier {
+  static class ItemByItemValidator extends BaseMutableStateValidator implements DefaultApplier {
 
     SchemaInternal[] schemas;
     SchemaInternal additionalItems;

--- a/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
@@ -14,7 +14,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.json.schema.NoSyncValidationException;
 import io.vertx.json.schema.Schema;

--- a/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/ItemsValidatorFactory.java
@@ -81,11 +81,11 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
           if (i >= schemas.length) {
             if (additionalItems != null) {
               context.markEvaluatedItem(i);
-              additionalItems.validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+              additionalItems.validateSync(context.lowerLevelContext(), arr.get(i));
             }
           } else {
             context.markEvaluatedItem(i);
-            schemas[i].validateSync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+            schemas[i].validateSync(context.lowerLevelContext(), arr.get(i));
           }
         }
       }
@@ -105,11 +105,11 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
           if (i >= schemas.length) {
             if (additionalItems != null) {
               context.markEvaluatedItem(i);
-              fut = additionalItems.validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+              fut = additionalItems.validateAsync(context.lowerLevelContext(), arr.get(i));
             } else continue;
           } else {
             context.markEvaluatedItem(i);
-            fut = schemas[i].validateAsync(context.lowerLevelContext(), JsonUtil.wrapJsonValue(arr.get(i)));
+            fut = schemas[i].validateAsync(context.lowerLevelContext(), arr.get(i));
           }
           if (fut.isComplete()) {
             if (fut.failed()) return Future.failedFuture(fut.cause());
@@ -140,7 +140,7 @@ public class ItemsValidatorFactory extends io.vertx.json.schema.common.ItemsVali
       List<Future> futures = new ArrayList<>();
       List<?> arr = (List<?>) in;
       for (int i = 0; i < arr.size(); i++) {
-        Object valToDefault = JsonUtil.wrapJsonValue(arr.get(i));
+        Object valToDefault = arr.get(i);
         if (i >= schemas.length) {
           if (additionalItems != null) {
             if (additionalItems.isSync()) {

--- a/src/main/java/io/vertx/json/schema/draft7/PropertyNamesValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/PropertyNamesValidatorFactory.java
@@ -35,7 +35,7 @@ public class PropertyNamesValidatorFactory extends BaseSingleSchemaValidatorFact
     return "propertyNames";
   }
 
-  class PropertyNamesValidator extends BaseSingleSchemaValidator {
+  static class PropertyNamesValidator extends BaseSingleSchemaValidator {
 
     public PropertyNamesValidator(MutableStateValidator parent) {
       super(parent);

--- a/src/main/java/io/vertx/json/schema/draft7/TypeValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft7/TypeValidatorFactory.java
@@ -36,7 +36,7 @@ public class TypeValidatorFactory implements ValidatorFactory {
       }
       boolean allowNull = allowedTypes.contains(JsonSchemaType.NULL);
       if (allowNull) allowedTypes.remove(JsonSchemaType.NULL);
-      return new TypeValidator(allowedTypes.toArray(new JsonSchemaType[allowedTypes.size()]), allowNull);
+      return new TypeValidator(allowedTypes.toArray(new JsonSchemaType[0]), allowNull);
     } catch (NullPointerException e) {
       throw new SchemaException(schema, "Null type keyword", e);
     } catch (ClassCastException e) {
@@ -70,7 +70,7 @@ public class TypeValidatorFactory implements ValidatorFactory {
     }
   }
 
-  class TypeValidator extends BaseSyncValidator {
+  static class TypeValidator extends BaseSyncValidator {
 
     final JsonSchemaType[] types;
     final boolean nullIsValid;

--- a/src/main/java/io/vertx/json/schema/draft7/dsl/StringFormat.java
+++ b/src/main/java/io/vertx/json/schema/draft7/dsl/StringFormat.java
@@ -26,7 +26,7 @@ public enum StringFormat {
   URI_TEMPLATE("uti-template"),
   TIME("time");
 
-  private String name;
+  private final String name;
 
   StringFormat(String name) {
     this.name = name;

--- a/src/main/java/io/vertx/json/schema/openapi3/TypeValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/openapi3/TypeValidatorFactory.java
@@ -54,7 +54,7 @@ public class TypeValidatorFactory implements ValidatorFactory {
     }
   }
 
-  class TypeValidator extends BaseSyncValidator {
+  static class TypeValidator extends BaseSyncValidator {
 
     final JsonSchemaType type;
 

--- a/src/test/java/io/vertx/json/schema/JavaUtilTest.java
+++ b/src/test/java/io/vertx/json/schema/JavaUtilTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.json.schema;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(VertxExtension.class)
+public class JavaUtilTest {
+
+  @Test
+  public void schemaAndValidationUsingMap(Vertx vertx) {
+
+    SchemaRouter router = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser parser = SchemaParser.createDraft7SchemaParser(router);
+
+    Schema schema = parser.parse(
+      new JsonObject()
+        .put("type", "object")
+        .put("required", new JsonArray().add("app"))
+        .put("properties", new JsonObject()
+          .put("app", new JsonObject()
+            .put("type", "string")
+            .put("minLength", 3))));
+
+    Map<String, String> json = new HashMap<>();
+    json.put("app", "abcd");
+
+    // OK
+    schema.validateSync(json);
+
+    try {
+      json = new HashMap<>();
+      json.put("app", "ab");
+      // Fail
+      schema.validateSync(json);
+      Assertions.fail("Should have thrown");
+    } catch (ValidationException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void schemaAndValidationUsingList(Vertx vertx) {
+
+    SchemaRouter router = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser parser = SchemaParser.createDraft7SchemaParser(router);
+
+    Schema schema = parser.parse(
+      new JsonObject()
+        .put("type", "array")
+        .put("items", new JsonObject()
+          .put("type", "number")));
+
+    List json = new ArrayList();
+    json.add(1);
+    json.add(2);
+    json.add(3);
+
+    // OK
+    schema.validateSync(json);
+
+    try {
+      json = new ArrayList<>();
+      json.add(1);
+      json.add(true);
+      json.add(3);
+
+      // Fail
+      schema.validateSync(json);
+      Assertions.fail("Should have thrown");
+    } catch (ValidationException e) {
+      // OK
+    }
+  }
+}

--- a/src/test/java/io/vertx/json/schema/JavaUtilTest.java
+++ b/src/test/java/io/vertx/json/schema/JavaUtilTest.java
@@ -91,4 +91,85 @@ public class JavaUtilTest {
       // OK
     }
   }
+
+  @Test
+  public void nestedComplexExample(Vertx vertx) {
+
+    SchemaRouter router = SchemaRouter.create(vertx, new SchemaRouterOptions());
+    SchemaParser parser = SchemaParser.createDraft7SchemaParser(router);
+
+    Schema schema = parser.parse(
+      new JsonObject(
+        "{\n" +
+          "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+          "  \"$id\": \"https://example.com/product.schema.json\",\n" +
+          "  \"title\": \"Product\",\n" +
+          "  \"description\": \"A product from Acme's catalog\",\n" +
+          "  \"type\": \"object\",\n" +
+          "  \"properties\": {\n" +
+          "    \"productId\": {\n" +
+          "      \"description\": \"The unique identifier for a product\",\n" +
+          "      \"type\": \"integer\"\n" +
+          "    },\n" +
+          "    \"productName\": {\n" +
+          "      \"description\": \"Name of the product\",\n" +
+          "      \"type\": \"string\"\n" +
+          "    },\n" +
+          "    \"price\": {\n" +
+          "      \"description\": \"The price of the product\",\n" +
+          "      \"type\": \"number\",\n" +
+          "      \"exclusiveMinimum\": 0\n" +
+          "    },\n" +
+          "    \"tags\": {\n" +
+          "      \"description\": \"Tags for the product\",\n" +
+          "      \"type\": \"array\",\n" +
+          "      \"items\": {\n" +
+          "        \"type\": \"string\"\n" +
+          "      },\n" +
+          "      \"minItems\": 1,\n" +
+          "      \"uniqueItems\": true\n" +
+          "    },\n" +
+          "    \"dimensions\": {\n" +
+          "      \"type\": \"object\",\n" +
+          "      \"properties\": {\n" +
+          "        \"length\": {\n" +
+          "          \"type\": \"number\"\n" +
+          "        },\n" +
+          "        \"width\": {\n" +
+          "          \"type\": \"number\"\n" +
+          "        },\n" +
+          "        \"height\": {\n" +
+          "          \"type\": \"number\"\n" +
+          "        }\n" +
+          "      },\n" +
+          "      \"required\": [ \"length\", \"width\", \"height\" ]\n" +
+          "    }\n" +
+          "  },\n" +
+          "  \"required\": [ \"productId\", \"productName\", \"price\" ]\n" +
+          "}\n"));
+
+
+    Map json = new HashMap();
+
+    json.put("productId", 1);
+    json.put("productName", "Vert.x");
+    json.put("price", 9.99);
+
+    List tags = new ArrayList();
+    tags.add("awesome");
+    tags.add("sauce");
+
+    json.put("tags", tags);
+
+    Map dimensions = new HashMap();
+    dimensions.put("length", 42);
+    dimensions.put("width", 56);
+    dimensions.put("height", 11);
+
+    json.put("dimensions", dimensions);
+
+
+    // OK
+    schema.validateSync(json);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes #38 

Currently, the validation only allows `JsonObject` and `JsonArray` for non-basic types. Many libraries could benefit from this project if we would allow besides the vert.x native types `java.util.Map` and `java.util.List`.

This PR addresses the issue by handling the internal of the validation using the JDK types instead of the vert.x ones.