### PR TITLE
Don't use classloaders to resolve resources. User vert.x core as it c…

### DIFF
--- a/src/main/java/io/vertx/json/schema/SchemaRouter.java
+++ b/src/main/java/io/vertx/json/schema/SchemaRouter.java
@@ -148,7 +148,7 @@ public interface SchemaRouter {
    * @return
    */
   static SchemaRouter create(Vertx vertx, SchemaRouterOptions schemaRouterOptions) {
-    return new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), schemaRouterOptions);
+    return new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), schemaRouterOptions);
   }
 
   /**
@@ -159,8 +159,8 @@ public interface SchemaRouter {
    * @param schemaRouterOptions
    * @return
    */
-  static SchemaRouter create(HttpClient client, FileSystem fs, SchemaRouterOptions schemaRouterOptions) {
-    return new SchemaRouterImpl(client, fs, schemaRouterOptions);
+  static SchemaRouter create(Vertx vertx, HttpClient client, FileSystem fs, SchemaRouterOptions schemaRouterOptions) {
+    return new SchemaRouterImpl(vertx, client, fs, schemaRouterOptions);
   }
 
 }

--- a/src/main/java/io/vertx/json/schema/common/URIUtils.java
+++ b/src/main/java/io/vertx/json/schema/common/URIUtils.java
@@ -37,19 +37,14 @@ public class URIUtils {
   }
 
   public static boolean isLocalURI(URI uri) {
-    return "jar".equals(uri.getScheme()) || "file".equals(uri.getScheme());
+    return "file".equals(uri.getScheme());
   }
 
   public static URI resolvePath(URI oldURI, String path) {
-    try {
-      if ("jar".equals(oldURI.getScheme())) {
-        String[] splittedJarURI = oldURI.getSchemeSpecificPart().split("!");
-        String newInternalJarPath = URI.create(splittedJarURI[1]).resolve(path).toString();
-        return new URI(oldURI.getScheme(), splittedJarURI[0] + "!" + newInternalJarPath, oldURI.getFragment());
-      } else if (path.isEmpty()) return oldURI;
-      else return oldURI.resolve(path);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
+    if (path.isEmpty()) {
+      return oldURI;
+    } else {
+      return oldURI.resolve(path);
     }
   }
 

--- a/src/test/java/io/vertx/json/schema/draft201909/Draft201909IntegrationTest.java
+++ b/src/test/java/io/vertx/json/schema/draft201909/Draft201909IntegrationTest.java
@@ -33,7 +33,7 @@ public class Draft201909IntegrationTest extends BaseIntegrationTest {
 
   @Override
   public Map.Entry<SchemaParser, Schema> buildSchemaFunction(Vertx vertx, Object schema, String testFileName) {
-    Draft201909SchemaParser parser = Draft201909SchemaParser.create(new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
+    Draft201909SchemaParser parser = Draft201909SchemaParser.create(new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
     Schema s = parser.parse(schema, Paths.get(this.getTckPath() + "/" + testFileName + ".json").toAbsolutePath().toUri());
     return new AbstractMap.SimpleImmutableEntry<>(parser, s);
   }
@@ -89,7 +89,7 @@ public class Draft201909IntegrationTest extends BaseIntegrationTest {
 
   @Override
   public SchemaParserInternal getSchemaParser(Vertx vertx) {
-    return Draft201909SchemaParser.create(new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
+    return Draft201909SchemaParser.create(new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
   }
 
   @Override

--- a/src/test/java/io/vertx/json/schema/draft7/Draft7IntegrationTest.java
+++ b/src/test/java/io/vertx/json/schema/draft7/Draft7IntegrationTest.java
@@ -68,7 +68,7 @@ public class Draft7IntegrationTest extends BaseIntegrationTest {
 
   @Override
   public SchemaParserInternal getSchemaParser(Vertx vertx) {
-    return Draft7SchemaParser.create(new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
+    return Draft7SchemaParser.create(new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
   }
 
   @Override

--- a/src/test/java/io/vertx/json/schema/draft7/ReproducersDraft7Test.java
+++ b/src/test/java/io/vertx/json/schema/draft7/ReproducersDraft7Test.java
@@ -34,7 +34,7 @@ public class ReproducersDraft7Test extends BaseIntegrationTest {
 
   @Override
   public SchemaParserInternal getSchemaParser(Vertx vertx) {
-    return Draft7SchemaParser.create(new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
+    return Draft7SchemaParser.create(new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
   }
 
   @Override

--- a/src/test/java/io/vertx/json/schema/oas3/OAS3IntegrationTest.java
+++ b/src/test/java/io/vertx/json/schema/oas3/OAS3IntegrationTest.java
@@ -62,7 +62,7 @@ public class OAS3IntegrationTest extends BaseIntegrationTest {
 
   @Override
   public SchemaParserInternal getSchemaParser(Vertx vertx) {
-    return OpenAPI3SchemaParser.create(new SchemaRouterImpl(vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
+    return OpenAPI3SchemaParser.create(new SchemaRouterImpl(vertx, vertx.createHttpClient(), vertx.fileSystem(), new SchemaRouterOptions()));
   }
 
   @Override


### PR DESCRIPTION
…over jar, osgi, graalvm and jlink

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Currently resources are loaded using class loaders. If a downstream project defines or changes class loaders it can be tricky to ensure that this code still behaves as expected.

Also the code assumes resources are either files or `jar://` resources. This isn't true for `jlink` images or `graalvm` native images. For this reason all class loader related code is replaced with vert.x core file resolver which handles all these cases and caches the resource for faster resolution.