### PR TITLE
Add missing @Source annotation to all examples

### DIFF
--- a/src/main/java/examples/JsonSchemaDslExamples.java
+++ b/src/main/java/examples/JsonSchemaDslExamples.java
@@ -1,6 +1,5 @@
 package examples;
 
-import io.vertx.docgen.Source;
 import io.vertx.json.schema.Schema;
 import io.vertx.json.schema.SchemaParser;
 import io.vertx.json.schema.common.dsl.SchemaBuilder;
@@ -10,7 +9,6 @@ import io.vertx.json.schema.draft7.dsl.StringFormat;
 import static io.vertx.json.schema.draft7.dsl.Keywords.*;
 import static io.vertx.json.schema.draft7.dsl.Schemas.*;
 
-@Source
 public class JsonSchemaDslExamples {
 
   public void createSchema() {

--- a/src/main/java/examples/JsonSchemaExamples.java
+++ b/src/main/java/examples/JsonSchemaExamples.java
@@ -3,10 +3,8 @@ package examples;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
-import io.vertx.docgen.Source;
 import io.vertx.json.schema.*;
 
-@Source
 public class JsonSchemaExamples {
 
   public void instantiate(Vertx vertx) {

--- a/src/main/java/examples/package-info.java
+++ b/src/main/java/examples/package-info.java
@@ -1,0 +1,4 @@
+@Source
+package examples;
+
+import io.vertx.docgen.Source;


### PR DESCRIPTION
The documentation on the website contains invalid code snippets. For example:
* https://vertx.io/docs/vertx-json-schema/java/#_synchronous_keywords
* https://vertx.io/docs/vertx-json-schema/java/#_asynchronous_keywords

It seems some example classes miss the `@Sample` annotation from the `vertx-docgen` project. This pull request adds a `package-info.java` file to the examples package declaring the annotation for the whole package.

I opted for the `package-info.java` file instead of adding the annotation to every class in order to avoid that the annotation appears in the documentation itself.

I tested the doc generation with this change and the snippets are correctly included.