### PR TITLE
PoC renaming the schema type to match the specification

### DIFF
--- a/src/main/java/examples/JsonSchemaDslExamples.java
+++ b/src/main/java/examples/JsonSchemaDslExamples.java
@@ -21,7 +21,7 @@ public class JsonSchemaDslExamples {
     arraySchema()
       .with(maxItems(10));
     schema() // Generic schema that accepts both arrays and integers
-      .with(type(SchemaType.ARRAY, SchemaType.INT));
+      .with(type(SchemaType.ARRAY, SchemaType.INTEGER));
   }
 
   public void createObject() {

--- a/src/main/java/io/vertx/json/schema/common/dsl/NumberSchemaBuilder.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/NumberSchemaBuilder.java
@@ -20,12 +20,13 @@ public final class NumberSchemaBuilder extends SchemaBuilder<NumberSchemaBuilder
 
   @Fluent
   public NumberSchemaBuilder asInteger() {
-    type(SchemaType.INT);
+    type(SchemaType.INTEGER);
     return this;
   }
 
   public boolean isIntegerSchema() {
-    return this.type.equals(SchemaType.INT);
+    // for legacy, while the deprecation is still in place
+    return this.type.equals(SchemaType.INT) || this.type.equals(SchemaType.INTEGER);
   }
 
 }

--- a/src/main/java/io/vertx/json/schema/common/dsl/SchemaType.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/SchemaType.java
@@ -11,7 +11,9 @@
 package io.vertx.json.schema.common.dsl;
 
 public enum SchemaType {
+  @Deprecated
   INT("integer"),
+  INTEGER("integer"),
   NUMBER("number"),
   BOOLEAN("boolean"),
   STRING("string"),

--- a/src/test/java/io/vertx/json/schema/draft7/dsl/SchemaBuilderTest.java
+++ b/src/test/java/io/vertx/json/schema/draft7/dsl/SchemaBuilderTest.java
@@ -44,7 +44,7 @@ public class SchemaBuilderTest {
     assertThat(
       schema()
         .with(
-          type(SchemaType.INT, SchemaType.STRING)
+          type(SchemaType.INTEGER, SchemaType.STRING)
         )
         .toJson()
     )


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Rename enum to better match the specification