### PR TITLE
Issues/new exception

### DIFF
--- a/src/main/generated/io/vertx/json/schema/OutputUnitConverter.java
+++ b/src/main/generated/io/vertx/json/schema/OutputUnitConverter.java
@@ -3,8 +3,7 @@ package io.vertx.json.schema;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+
 import java.util.Base64;
 
 /**
@@ -52,7 +51,7 @@ public class OutputUnitConverter {
           break;
         case "keyword":
           if (member.getValue() instanceof String) {
-            obj.setKeyword((String)member.getValue());
+            obj.setAbsoluteKeywordLocation((String)member.getValue());
           }
           break;
         case "keywordLocation":
@@ -90,8 +89,8 @@ public class OutputUnitConverter {
     if (obj.getInstanceLocation() != null) {
       json.put("instanceLocation", obj.getInstanceLocation());
     }
-    if (obj.getKeyword() != null) {
-      json.put("keyword", obj.getKeyword());
+    if (obj.getAbsoluteKeywordLocation() != null) {
+      json.put("keyword", obj.getAbsoluteKeywordLocation());
     }
     if (obj.getKeywordLocation() != null) {
       json.put("keywordLocation", obj.getKeywordLocation());

--- a/src/main/generated/io/vertx/json/schema/OutputUnitConverter.java
+++ b/src/main/generated/io/vertx/json/schema/OutputUnitConverter.java
@@ -3,7 +3,8 @@ package io.vertx.json.schema;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
-
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
 /**
@@ -19,6 +20,11 @@ public class OutputUnitConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, OutputUnit obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "absoluteKeywordLocation":
+          if (member.getValue() instanceof String) {
+            obj.setAbsoluteKeywordLocation((String)member.getValue());
+          }
+          break;
         case "annotations":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<io.vertx.json.schema.OutputUnit> list =  new java.util.ArrayList<>();
@@ -49,11 +55,6 @@ public class OutputUnitConverter {
             obj.setInstanceLocation((String)member.getValue());
           }
           break;
-        case "keyword":
-          if (member.getValue() instanceof String) {
-            obj.setAbsoluteKeywordLocation((String)member.getValue());
-          }
-          break;
         case "keywordLocation":
           if (member.getValue() instanceof String) {
             obj.setKeywordLocation((String)member.getValue());
@@ -73,6 +74,9 @@ public class OutputUnitConverter {
   }
 
   public static void toJson(OutputUnit obj, java.util.Map<String, Object> json) {
+    if (obj.getAbsoluteKeywordLocation() != null) {
+      json.put("absoluteKeywordLocation", obj.getAbsoluteKeywordLocation());
+    }
     if (obj.getAnnotations() != null) {
       JsonArray array = new JsonArray();
       obj.getAnnotations().forEach(item -> array.add(item.toJson()));
@@ -88,9 +92,6 @@ public class OutputUnitConverter {
     }
     if (obj.getInstanceLocation() != null) {
       json.put("instanceLocation", obj.getInstanceLocation());
-    }
-    if (obj.getAbsoluteKeywordLocation() != null) {
-      json.put("keyword", obj.getAbsoluteKeywordLocation());
     }
     if (obj.getKeywordLocation() != null) {
       json.put("keywordLocation", obj.getKeywordLocation());

--- a/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
+++ b/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
@@ -29,9 +29,13 @@ public final class JsonSchemaValidationException extends Exception {
   }
 
   public JsonSchemaValidationException(String message, Throwable cause, String location, StackTraceElement stackTraceElement) {
-    super(message, cause, true, true);
+    super(message, cause, stackTraceElement != null, stackTraceElement != null);
     this.location = location;
-    setStackTrace(new StackTraceElement[]{stackTraceElement});
+    if (stackTraceElement != null) {
+      setStackTrace(new StackTraceElement[]{
+        stackTraceElement
+      });
+    }
   }
 
   /**

--- a/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
+++ b/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
@@ -11,12 +11,11 @@
 package io.vertx.json.schema;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.VertxException;
 
 /**
  * This is the main class for every JsonSchemaValidation flow related errors
  */
-public final class JsonSchemaValidationException extends VertxException {
+public final class JsonSchemaValidationException extends Exception {
 
   final private String location;
 
@@ -30,7 +29,7 @@ public final class JsonSchemaValidationException extends VertxException {
   }
 
   public JsonSchemaValidationException(String message, Throwable cause, String location, StackTraceElement stackTraceElement) {
-    super(message, cause, false);
+    super(message, cause, true, true);
     this.location = location;
     setStackTrace(new StackTraceElement[]{stackTraceElement});
   }

--- a/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
+++ b/src/main/java/io/vertx/json/schema/JsonSchemaValidationException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.json.schema;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.VertxException;
+
+/**
+ * This is the main class for every JsonSchemaValidation flow related errors
+ */
+public final class JsonSchemaValidationException extends VertxException {
+
+  final private String location;
+
+  public JsonSchemaValidationException(String message, Throwable cause, String location) {
+    super(message, cause);
+    this.location = location;
+  }
+
+  public JsonSchemaValidationException(String message, String location, StackTraceElement stackTraceElement) {
+    this(message, null, location, stackTraceElement);
+  }
+
+  public JsonSchemaValidationException(String message, Throwable cause, String location, StackTraceElement stackTraceElement) {
+    super(message, cause, false);
+    this.location = location;
+    setStackTrace(new StackTraceElement[]{stackTraceElement});
+  }
+
+  /**
+   * @return the location that failed the validation, if any
+   */
+  @Nullable
+  public String location() {
+    return location;
+  }
+}

--- a/src/main/java/io/vertx/json/schema/OutputUnit.java
+++ b/src/main/java/io/vertx/json/schema/OutputUnit.java
@@ -154,30 +154,30 @@ public class OutputUnit {
 
     // if valid is null, it means that we are a caused by error
     if (valid == null) {
-      final String location = getInstanceLocation();
+      final String location = getAbsoluteKeywordLocation();
 
       throw new JsonSchemaValidationException(
         msg == null ? "JsonSchema Validation error" : msg,
         location,
         // add some information to the stack trace
-        createStackTraceElement(location, getAbsoluteKeywordLocation(), getKeywordLocation()));
+        createStackTraceElement());
     } else {
       if (!valid) {
         // valid is "false" we need to throw an exception
         if (errors == null || errors.isEmpty()) {
-          final String location = getInstanceLocation();
+          final String location = getAbsoluteKeywordLocation();
 
           // there are no sub errors, but the validation failed
           throw new JsonSchemaValidationException(
             msg == null ? "JsonSchema Validation error" : msg,
             location,
             // add some information to the stack trace
-            createStackTraceElement(location, getAbsoluteKeywordLocation(), getKeywordLocation()));
+            createStackTraceElement());
         } else {
           // there are sub errors, we need to cycle them and create a chain of exceptions
           JsonSchemaValidationException lastException = null;
           for (final OutputUnit error : errors) {
-            final String location = error.getInstanceLocation();
+            final String location = error.getAbsoluteKeywordLocation();
 
             JsonSchemaValidationException cause;
             cause = new JsonSchemaValidationException(
@@ -185,22 +185,25 @@ public class OutputUnit {
               lastException,
               location,
               // add some information to the stack trace
-              createStackTraceElement(location, error.getAbsoluteKeywordLocation(), error.getKeywordLocation()));
+              error.createStackTraceElement());
             lastException = cause;
           }
           if (msg == null) {
             throw lastException;
           } else {
             // one final wrap as there is extra error message in the unit
-            throw new JsonSchemaValidationException(msg, lastException, getInstanceLocation());
+            throw new JsonSchemaValidationException(msg, lastException, getAbsoluteKeywordLocation());
           }
         }
       }
     }
   }
 
-  private static StackTraceElement createStackTraceElement(String location, String keyword, String keywordLocation) {
-    return new StackTraceElement("[" + location + "]", "<" + keyword + ">", keywordLocation, -1);
+  private StackTraceElement createStackTraceElement() {
+    if (instanceLocation == null && keywordLocation == null) {
+      return null;
+    }
+    return new StackTraceElement("[" + keywordLocation + "]", "<" + instanceLocation + ">", absoluteKeywordLocation, -1);
   }
 
   /**

--- a/src/main/java/io/vertx/json/schema/OutputUnit.java
+++ b/src/main/java/io/vertx/json/schema/OutputUnit.java
@@ -173,41 +173,38 @@ public class OutputUnit {
 
     // if valid is null, it means that we are a caused by error
     if (valid == null) {
+      final String location = urlFormatter.apply(getInstanceLocation());
+
       throw new JsonSchemaValidationException(
         msg == null ? "JsonSchema Validation error" : msg,
-        urlFormatter.apply(getInstanceLocation()),
+        location,
         // add some information to the stack trace
-        new StackTraceElement("[" + urlFormatter.apply(getInstanceLocation()) + "]", "<" + getKeyword() + ">", getKeywordLocation(), -1));
+        createStackTraceElement(location, getKeyword(), getKeywordLocation()));
     } else {
       if (!valid) {
         // valid is "false" we need to throw an exception
         if (errors.isEmpty()) {
+          final String location = urlFormatter.apply(getInstanceLocation());
+
           // there are no sub errors, but the validation failed
           throw new JsonSchemaValidationException(
             msg == null ? "JsonSchema Validation error" : msg,
-            urlFormatter.apply(getInstanceLocation()),
+            location,
             // add some information to the stack trace
-              new StackTraceElement("[" + urlFormatter.apply(getInstanceLocation()) + "]", "<" + getKeyword() + ">", getKeywordLocation(), -1));
+            createStackTraceElement(location, getKeyword(), getKeywordLocation()));
         } else {
-          final JsonSchemaValidationException exception;
           // there are sub errors, we need to cycle them and create a chain of exceptions
           JsonSchemaValidationException lastException = null;
           for (final OutputUnit error : errors) {
+            final String location = urlFormatter.apply(error.getInstanceLocation());
+
             JsonSchemaValidationException cause;
-            if (lastException == null) {
-              cause = new JsonSchemaValidationException(
-                error.getError(),
-                urlFormatter.apply(error.getInstanceLocation()),
-                // add some information to the stack trace
-                new StackTraceElement("[" + urlFormatter.apply(error.getInstanceLocation()) + "]", "<" + error.getKeyword() + ">", error.getKeywordLocation(), -1));
-            } else {
-              cause = new JsonSchemaValidationException(
-                error.getError(),
-                lastException,
-                urlFormatter.apply(error.getInstanceLocation()),
-                // add some information to the stack trace
-                new StackTraceElement("[" + urlFormatter.apply(error.getInstanceLocation()) + "]", "<" + error.getKeyword() + ">", error.getKeywordLocation(), -1));
-            }
+            cause = new JsonSchemaValidationException(
+              error.getError(),
+              lastException,
+              location,
+              // add some information to the stack trace
+              createStackTraceElement(location, error.getKeyword(), error.getKeywordLocation()));
             lastException = cause;
           }
           if (msg == null) {
@@ -219,6 +216,10 @@ public class OutputUnit {
         }
       }
     }
+  }
+
+  private static StackTraceElement createStackTraceElement(String location, String keyword, String keywordLocation) {
+    return new StackTraceElement("[" + location + "]", "<" + keyword + ">", keywordLocation, -1);
   }
 
   /**

--- a/src/main/java/io/vertx/json/schema/OutputUnit.java
+++ b/src/main/java/io/vertx/json/schema/OutputUnit.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 public class OutputUnit {
 
   private Boolean valid;
-  private String keyword;
+  private String absoluteKeywordLocation;
   private String keywordLocation;
   private String instanceLocation;
   private String error;
@@ -36,7 +36,6 @@ public class OutputUnit {
   private String schemaLocation;
 
   public OutputUnit() {
-    valid = true;
   }
 
   public OutputUnit(JsonObject json) {
@@ -47,9 +46,9 @@ public class OutputUnit {
     this.valid = valid;
   }
 
-  public OutputUnit(String instanceLocation, String keyword, String keywordLocation, String error) {
+  public OutputUnit(String instanceLocation, String absoluteKeywordLocation, String keywordLocation, String error) {
     this.instanceLocation = instanceLocation;
-    this.keyword = keyword;
+    this.absoluteKeywordLocation = absoluteKeywordLocation;
     this.keywordLocation = keywordLocation;
     this.error = error;
   }
@@ -63,12 +62,12 @@ public class OutputUnit {
     return this;
   }
 
-  public String getKeyword() {
-    return keyword;
+  public String getAbsoluteKeywordLocation() {
+    return absoluteKeywordLocation;
   }
 
-  public OutputUnit setKeyword(String keyword) {
-    this.keyword = keyword;
+  public OutputUnit setAbsoluteKeywordLocation(String absoluteKeywordLocation) {
+    this.absoluteKeywordLocation = absoluteKeywordLocation;
     return this;
   }
 
@@ -179,11 +178,11 @@ public class OutputUnit {
         msg == null ? "JsonSchema Validation error" : msg,
         location,
         // add some information to the stack trace
-        createStackTraceElement(location, getKeyword(), getKeywordLocation()));
+        createStackTraceElement(location, getAbsoluteKeywordLocation(), getKeywordLocation()));
     } else {
       if (!valid) {
         // valid is "false" we need to throw an exception
-        if (errors.isEmpty()) {
+        if (errors == null || errors.isEmpty()) {
           final String location = urlFormatter.apply(getInstanceLocation());
 
           // there are no sub errors, but the validation failed
@@ -191,7 +190,7 @@ public class OutputUnit {
             msg == null ? "JsonSchema Validation error" : msg,
             location,
             // add some information to the stack trace
-            createStackTraceElement(location, getKeyword(), getKeywordLocation()));
+            createStackTraceElement(location, getAbsoluteKeywordLocation(), getKeywordLocation()));
         } else {
           // there are sub errors, we need to cycle them and create a chain of exceptions
           JsonSchemaValidationException lastException = null;
@@ -204,7 +203,7 @@ public class OutputUnit {
               lastException,
               location,
               // add some information to the stack trace
-              createStackTraceElement(location, error.getKeyword(), error.getKeywordLocation()));
+              createStackTraceElement(location, error.getAbsoluteKeywordLocation(), error.getKeywordLocation()));
             lastException = cause;
           }
           if (msg == null) {
@@ -227,7 +226,7 @@ public class OutputUnit {
    */
   @GenIgnore
   public ValidationException toException(Object input) {
-    return new ValidationException(error + ": { errors: " + formatExceptions(errors) + ", annotations: " + formatExceptions(annotations) + "}", keyword, input, true) {
+    return new ValidationException(error + ": { errors: " + formatExceptions(errors) + ", annotations: " + formatExceptions(annotations) + "}", absoluteKeywordLocation, input, true) {
     };
   }
 

--- a/src/main/java/io/vertx/json/schema/OutputUnit.java
+++ b/src/main/java/io/vertx/json/schema/OutputUnit.java
@@ -12,11 +12,14 @@ package io.vertx.json.schema;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.VertxException;
 import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.impl.URL;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @DataObject(generateConverter = true)
@@ -30,6 +33,8 @@ public class OutputUnit {
 
   private List<OutputUnit> errors;
   private List<OutputUnit> annotations;
+
+  private String schemaLocation;
 
   public OutputUnit() {
     valid = true;
@@ -147,6 +152,75 @@ public class OutputUnit {
     }
     this.annotations.addAll(annotations);
     return this;
+  }
+
+  @GenIgnore
+  public OutputUnit setSchemaLocation(String schemaLocation) {
+    this.schemaLocation = schemaLocation;
+    return this;
+  }
+
+  public void checkValidity() throws VertxException {
+    final URL baseUri = schemaLocation != null ? new URL(schemaLocation) : null;
+    final VertxException exception;
+    String msg = getError();
+
+    final Function<String, String> urlFormatter = fragment -> {
+      if (baseUri == null) {
+        return fragment;
+      }
+      return new URL(fragment, baseUri).href();
+    };
+
+
+    // if valid is null, it means that we are a caused by error
+    if (valid == null) {
+      exception = new VertxException(msg == null ? "JsonSchema Validation error" : msg, false);
+      // add some information to the stack trace
+      exception.setStackTrace(
+        new StackTraceElement[]{
+          new StackTraceElement("[" + urlFormatter.apply(getInstanceLocation()) + "]", "<" + getKeyword() + ">", getKeywordLocation(), -1)
+        }
+      );
+    } else {
+      if (!valid) {
+        // valid is "false" we need to throw an exception
+
+        if (errors.isEmpty()) {
+          // there are no sub errors, but the validation failed
+          exception = new VertxException(msg == null ? "JsonSchema Validation error" : msg, false);
+          // add some information to the stack trace
+          exception.setStackTrace(
+            new StackTraceElement[]{
+              new StackTraceElement("[" + urlFormatter.apply(getInstanceLocation()) + "]", "<" + getKeyword() + ">", getKeywordLocation(), -1)
+            }
+          );
+        } else {
+          // there are sub errors, we need to cycle them and create a chain of exceptions
+          VertxException lastException = null;
+          for (int i = errors.size() - 1; i >= 0; i--) {
+            final OutputUnit error = errors.get(i);
+            VertxException cause;
+            if (lastException == null) {
+              cause = new VertxException(error.getError(), false);
+            } else {
+              cause = new VertxException(error.getError(), lastException, false);
+            }
+            // add some information to the stack trace
+            cause.setStackTrace(
+              new StackTraceElement[]{
+                new StackTraceElement("[" + urlFormatter.apply(error.getInstanceLocation()) + "]", "<" + error.getKeyword() + ">", error.getKeywordLocation(), -1)
+              }
+            );
+            lastException = cause;
+          }
+          exception = new VertxException(msg == null ? "JsonSchema Validation error" : msg, lastException, false);
+        }
+
+        throw exception;
+      }
+    }
+
   }
 
   /**

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -76,7 +76,8 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       if (schema == BooleanSchema.TRUE) {
         return new OutputUnit(true);
       } else {
-        return new OutputUnit(false).setErrors(Collections.singletonList(new OutputUnit(instanceLocation, "false", instanceLocation, "False boolean schema")));
+        return new OutputUnit(false)
+          .setErrors(outputFormat == OutputFormat.Flag ? null : Collections.singletonList(new OutputUnit(instanceLocation, "false", instanceLocation, "False boolean schema")));
       }
     }
 
@@ -113,7 +114,9 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       );
       if (!result.getValid()) {
         errors.add(new OutputUnit(instanceLocation, "$recursiveRef", keywordLocation, "A sub-schema had errors"));
-        errors.addAll(result.getErrors());
+        if (result.getErrors() != null) {
+          errors.addAll(result.getErrors());
+        }
       }
     }
 
@@ -141,10 +144,13 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       );
       if (!result.getValid()) {
         errors.add(new OutputUnit(instanceLocation, "$ref", keywordLocation, "A subschema had errors"));
-        errors.addAll(result.getErrors());
+        if (result.getErrors() != null) {
+          errors.addAll(result.getErrors());
+        }
       }
       if (draft == Draft.DRAFT4 || draft == Draft.DRAFT7) {
-        return new OutputUnit(errors.isEmpty()).setErrors(errors);
+        return new OutputUnit(errors.isEmpty())
+          .setErrors(outputFormat == OutputFormat.Flag ? null : errors.isEmpty() ? null : errors);
       }
     }
 
@@ -864,7 +870,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     }
 
     return new OutputUnit(errors.isEmpty())
-      .setErrors(errors.isEmpty() ? null : errors)
-      .setAnnotations(annotations.isEmpty() ? null : annotations);
+      .setErrors(outputFormat == OutputFormat.Flag ? null : errors.isEmpty() ? null : errors)
+      .setAnnotations(outputFormat == OutputFormat.Flag ? null : annotations.isEmpty() ? null : annotations);
   }
 }

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -61,13 +61,19 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
 
   @Override
   public OutputUnit validate(Object instance) throws SchemaException {
-    return validate(
+    OutputUnit result = validate(
       instance,
       schema,
       null,
       "#",
       "#",
       new HashSet<>());
+
+    // attach the absolute uri to the unit in order to produce proper error messages
+    if (schema instanceof JsonObjectSchema) {
+      result.setSchemaLocation(schema.get("__absolute_uri__"));
+    }
+    return result;
   }
 
   private OutputUnit validate(Object _instance, JsonSchema schema, JsonSchema _recursiveAnchor, String instanceLocation, String schemaLocation, Set<Object> evaluated) throws SchemaException {

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -76,8 +76,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       if (schema == BooleanSchema.TRUE) {
         return new OutputUnit(true);
       } else {
-        return new OutputUnit(false)
-          .setErrors(outputFormat == OutputFormat.Flag ? null : Collections.singletonList(new OutputUnit(instanceLocation, null, null, "False boolean schema")));
+        return new OutputUnit(false);
       }
     }
 
@@ -102,13 +101,12 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         recursiveAnchor == null
           ? lookup.get(schema.<String>get("__absolute_recursive_ref__"))
           : recursiveAnchor;
-      final String keywordLocation = schemaLocation + "/$recursiveRef";
       final OutputUnit result = validate(
         instance,
         recursiveAnchor == null ? schema : recursiveAnchor,
         refSchema,
         instanceLocation,
-        keywordLocation,
+        schemaLocation + "/$recursiveRef",
         baseLocation  + "/$recursiveRef",
         evaluated
       );
@@ -132,13 +130,12 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       }
 
       final JsonSchema refSchema = lookup.get(uri);
-      final String keywordLocation = schema.get("$ref");
       final OutputUnit result = validate(
         instance,
         refSchema,
         recursiveAnchor,
         instanceLocation,
-        keywordLocation,
+        schema.get("$ref"),
         baseLocation + "/$ref",
         evaluated
       );
@@ -198,13 +195,12 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     }
 
     if (schema.containsKey("not")) {
-      final String keywordLocation = schemaLocation + "/not";
       final OutputUnit result = validate(
         instance,
         Schemas.wrap((JsonObject) schema, "not"),
         recursiveAnchor,
         instanceLocation,
-        keywordLocation,
+        schemaLocation + "/not",
         baseLocation + "/not",
         new HashSet<>()
       );
@@ -216,7 +212,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     Set<Object> subEvaluateds = new HashSet<>();
 
     if (schema.containsKey("anyOf")) {
-      final String keywordLocation = schemaLocation + "/anyOf";
       final int errorsLength = errors.size();
       boolean anyValid = false;
       for (int i = 0; i < schema.<JsonArray>get("anyOf").size(); i++) {
@@ -226,7 +221,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           Schemas.wrap(schema.get("anyOf"), i),
           schema.<Boolean>get("$recursiveAnchor", false) ? recursiveAnchor : null,
           instanceLocation,
-          keywordLocation + "/" + i,
+          schemaLocation + "/anyOf/" + i,
           baseLocation + "/anyOf/" + i,
           subEvaluated
         );
@@ -246,7 +241,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     }
 
     if (schema.containsKey("allOf")) {
-      final String keywordLocation = schemaLocation + "/allOf";
       final int errorsLength = errors.size();
       boolean allValid = true;
       for (int i = 0; i < schema.<JsonArray>get("allOf").size(); i++) {
@@ -256,7 +250,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           Schemas.wrap(schema.get("allOf"), i),
           schema.<Boolean>get("$recursiveAnchor", false) ? recursiveAnchor : null,
           instanceLocation,
-          keywordLocation + "/" + i,
+          schemaLocation + "/allOf/" + i,
           baseLocation + "/allOf/" + i,
           subEvaluated
         );
@@ -276,7 +270,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     }
 
     if (schema.containsKey("oneOf")) {
-      final String keywordLocation = schemaLocation + "/oneOf";
       final int errorsLength = errors.size();
       int matches = 0;
       for (int i = 0; i < schema.<JsonArray>get("oneOf").size(); i++) {
@@ -286,7 +279,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           Schemas.wrap(schema.get("oneOf"), i),
           schema.<Boolean>get("$recursiveAnchor", false) ? recursiveAnchor : null,
           instanceLocation,
-          keywordLocation + "/" + i,
+          schemaLocation + "/oneOf/" + i,
           baseLocation + "/oneOf/" + i,
           subEvaluated
         );
@@ -312,13 +305,12 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     }
 
     if (schema.containsKey("if")) {
-      final String keywordLocation = schemaLocation + "/if";
       final OutputUnit conditionResult = validate(
         instance,
         Schemas.wrap((JsonObject) schema, "if"),
         recursiveAnchor,
         instanceLocation,
-        keywordLocation,
+        schemaLocation + "/if",
         baseLocation + "/if",
         evaluated
       );
@@ -380,7 +372,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (schema.containsKey("propertyNames")) {
-          final String keywordLocation = schemaLocation + "/propertyNames";
           for (final String key : ((JsonObject) instance).fieldNames()) {
             final String subInstancePointer = instanceLocation + "/" + Pointers.encode(key);
             final OutputUnit result = validate(
@@ -388,7 +379,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               Schemas.wrap((JsonObject) schema, "propertyNames"),
               recursiveAnchor,
               subInstancePointer,
-              keywordLocation,
+              schemaLocation + "/propertyNames",
               baseLocation + "/propertyNames",
               new HashSet<>()
             );
@@ -402,7 +393,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (schema.containsKey("dependentRequired")) {
-          final String keywordLocation = schemaLocation + "/dependantRequired";
           for (final String key : schema.<JsonObject>get("dependentRequired").fieldNames()) {
             if (((JsonObject) instance).containsKey(key)) {
               final JsonArray required = schema.<JsonObject>get("dependentRequired").getJsonArray(key);
@@ -417,14 +407,13 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
 
         if (schema.containsKey("dependentSchemas")) {
           for (final String key : schema.<JsonObject>get("dependentSchemas").fieldNames()) {
-            final String keywordLocation = schemaLocation + "/dependentSchemas";
             if (((JsonObject) instance).containsKey(key)) {
               final OutputUnit result = validate(
                 instance,
                 Schemas.wrap(schema.get("dependentSchemas"), key),
                 recursiveAnchor,
                 instanceLocation,
-                keywordLocation + "/" + Pointers.encode(key),
+                schemaLocation + "/dependentSchemas/" + Pointers.encode(key),
                 baseLocation + "/dependentSchemas/" + Pointers.encode(key),
                 evaluated
               );
@@ -439,7 +428,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (schema.containsKey("dependencies")) {
-          final String keywordLocation = schemaLocation + "/dependencies";
           for (final String key : schema.<JsonObject>get("dependencies").fieldNames()) {
             if (((JsonObject) instance).containsKey(key)) {
               final Object propsOrSchema = schema.<JsonObject>get("dependencies").getValue(key);
@@ -455,7 +443,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                   Schemas.wrap(schema.get("dependencies"), key),
                   recursiveAnchor,
                   instanceLocation,
-                  keywordLocation + "/" + Pointers.encode(key),
+                  schemaLocation + "/dependencies/" + Pointers.encode(key),
                   baseLocation + "/dependencies/" + Pointers.encode(key),
                   new HashSet<>()
                 );
@@ -475,7 +463,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         boolean stop = false;
 
         if (schema.containsKey("properties")) {
-          final String keywordLocation = schemaLocation + "/properties";
           for (final String key : schema.<JsonObject>get("properties").fieldNames()) {
             if (!((JsonObject) instance).containsKey(key)) {
               continue;
@@ -486,7 +473,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               Schemas.wrap(schema.get("properties"), key),
               recursiveAnchor,
               subInstancePointer,
-              keywordLocation + "/" + Pointers.encode(key),
+              schemaLocation + "/properties/" + Pointers.encode(key),
               baseLocation + "/properties/" + Pointers.encode(key),
               new HashSet<>()
             );
@@ -507,7 +494,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (!stop && schema.containsKey("patternProperties")) {
-          final String keywordLocation = schemaLocation + "/patternProperties";
           for (final String pattern : schema.<JsonObject>get("patternProperties").fieldNames()) {
             final Pattern regex = Pattern.compile(pattern);
             for (final String key : ((JsonObject) instance).fieldNames()) {
@@ -520,7 +506,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 Schemas.wrap(schema.get("patternProperties"), pattern),
                 recursiveAnchor,
                 subInstancePointer,
-                keywordLocation + "/" + Pointers.encode(pattern),
+                schemaLocation + "/patternProperties/" + Pointers.encode(pattern),
                 baseLocation + "/patternProperties/" + Pointers.encode(pattern),
                 new HashSet<>()
               );
@@ -539,7 +525,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (!stop && schema.containsKey("additionalProperties")) {
-          final String keywordLocation = schemaLocation + "/additionalProperties";
           for (final String key : ((JsonObject) instance).fieldNames()) {
             if (thisEvaluated.contains(key)) {
               continue;
@@ -550,7 +535,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               Schemas.wrap((JsonObject) schema, "additionalProperties"),
               recursiveAnchor,
               subInstancePointer,
-              keywordLocation,
+              schemaLocation + "/additionalProperties",
               baseLocation + "/additionalProperties",
               new HashSet<>()
             );
@@ -568,7 +553,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             }
           }
         } else if (!stop && schema.containsKey("unevaluatedProperties")) {
-          final String keywordLocation = schemaLocation + "/unevaluatedProperties";
           for (final String key : ((JsonObject) instance).fieldNames()) {
             if (!evaluated.contains(key)) {
               final String subInstancePointer = instanceLocation + "/" + Pointers.encode(key);
@@ -577,7 +561,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 Schemas.wrap((JsonObject) schema, "unevaluatedProperties"),
                 recursiveAnchor,
                 subInstancePointer,
-                keywordLocation,
+                schemaLocation + "/unevaluatedProperties",
                 baseLocation + "/unevaluatedProperties",
                 new HashSet<>()
               );
@@ -608,7 +592,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         boolean stop = false;
 
         if (schema.containsKey("prefixItems")) {
-          final String keywordLocation = schemaLocation + "/prefixItems";
           final int length2 = Math.min(schema.<JsonArray>get("prefixItems").size(), length);
           for (; i < length2; i++) {
             final OutputUnit result = validate(
@@ -616,7 +599,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               Schemas.wrap(schema.get("prefixItems"), i),
               recursiveAnchor,
               instanceLocation + "/" + i,
-              keywordLocation + "/" + i,
+              schemaLocation + "/prefixItems/" + i,
               baseLocation + "/prefixItems/" + i,
               new HashSet<>()
             );
@@ -635,7 +618,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (schema.containsKey("items")) {
-          final String keywordLocation = schemaLocation + "/items";
           if (schema.get("items") instanceof JsonArray) {
             final int length2 = Math.min(schema.<JsonArray>get("items").size(), length);
             for (; i < length2; i++) {
@@ -644,7 +626,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 Schemas.wrap(schema.get("items"), i),
                 recursiveAnchor,
                 instanceLocation + "/" + i,
-                keywordLocation + "/" + i,
+                schemaLocation + "/items/" + i,
                 baseLocation + "/items/" + i,
                 new HashSet<>()
               );
@@ -667,7 +649,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 Schemas.wrap((JsonObject) schema, "items"),
                 recursiveAnchor,
                 instanceLocation + "/" + i,
-                keywordLocation,
+                schemaLocation + "/items",
                 baseLocation + "/items",
                 new HashSet<>()
               );
@@ -715,7 +697,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           } else if (schema.containsKey("minContains") && length < schema.<Integer>get("minContains")) {
             errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array has less items (" + length + ") than minContains (" + schema.get("minContains") + ")"));
           } else {
-            final String keywordLocation = schemaLocation + "/contains";
             final int errorsLength = errors.size();
             int contained = 0;
             for (int j = 0; j < length; j++) {
@@ -724,7 +705,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 Schemas.wrap((JsonObject) schema, "contains"),
                 recursiveAnchor,
                 instanceLocation + "/" + i,
-                keywordLocation,
+                schemaLocation + "/contains",
                 baseLocation + "/contains",
                 new HashSet<>()
               );
@@ -757,7 +738,6 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (!stop && schema.containsKey("unevaluatedItems")) {
-          final String keywordLocation = schemaLocation + "/unevaluatedItems";
           for (; i < length; i++) {
             if (evaluated.contains(i)) {
               continue;
@@ -767,7 +747,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               Schemas.wrap((JsonObject) schema, "unevaluatedItems"),
               recursiveAnchor,
               instanceLocation + "/" + i,
-              keywordLocation,
+              schemaLocation + "/unevaluatedItems",
               baseLocation + "/unevaluatedItems",
               new HashSet<>()
             );

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -77,7 +77,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         return new OutputUnit(true);
       } else {
         return new OutputUnit(false)
-          .setErrors(outputFormat == OutputFormat.Flag ? null : Collections.singletonList(new OutputUnit(instanceLocation, "false", instanceLocation, "False boolean schema")));
+          .setErrors(outputFormat == OutputFormat.Flag ? null : Collections.singletonList(new OutputUnit(instanceLocation, null, null, "False boolean schema")));
       }
     }
 
@@ -113,7 +113,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         evaluated
       );
       if (!result.getValid()) {
-        errors.add(new OutputUnit(instanceLocation, "$recursiveRef", keywordLocation, "A sub-schema had errors"));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/$recursiveRef"), baseLocation + "/$recursiveRef", "A sub-schema had errors"));
         if (result.getErrors() != null) {
           errors.addAll(result.getErrors());
         }
@@ -143,7 +143,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         evaluated
       );
       if (!result.getValid()) {
-        errors.add(new OutputUnit(instanceLocation, "$ref", keywordLocation, "A subschema had errors"));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/$ref"), baseLocation + "/$ref", "A subschema had errors"));
         if (result.getErrors() != null) {
           errors.addAll(result.getErrors());
         }
@@ -167,33 +167,33 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
       }
       if (!valid) {
-        errors.add(new OutputUnit(instanceLocation, "type", schemaLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + String.join(", ", type.getList())));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/type"), baseLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + String.join(", ", type.getList())));
       }
     } else if ("integer".equals(schema.get("type"))) {
       if (!"number".equals(instanceType) || !Numbers.isInteger(instance)) {
-        errors.add(new OutputUnit(instanceLocation, "type", schemaLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + schema.get("type")));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/type"), baseLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + schema.get("type")));
       }
     } else if (schema.containsKey("type") && !instanceType.equals(schema.get("type"))) {
-      errors.add(new OutputUnit(instanceLocation, "type", schemaLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + schema.get("type")));
+      errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/type"), baseLocation + "/type", "Instance type " + instanceType + " is invalid. Expected " + schema.get("type")));
     }
 
     if (schema.containsKey("const")) {
       if ("object".equals(instanceType) || "array".equals(instanceType)) {
         if (!JSON.deepCompare(instance, schema.get("const"))) {
-          errors.add(new OutputUnit(instanceLocation, "const", schemaLocation + "/const", "Instance does not match " + Json.encode(schema.get("const"))));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/const"), baseLocation + "/const", "Instance does not match " + Json.encode(schema.get("const"))));
         }
       } else if (!Utils.Objects.equals(schema.get("const"), instance)) {
-        errors.add(new OutputUnit(instanceLocation, "const", schemaLocation + "/const", "Instance does not match " + Json.encode(schema.get("const"))));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/const"), baseLocation + "/const", "Instance does not match " + Json.encode(schema.get("const"))));
       }
     }
 
     if (schema.containsKey("enum")) {
       if ("object".equals(instanceType) || "array".equals(instanceType)) {
         if (schema.<JsonArray>get("enum").stream().noneMatch(value -> JSON.deepCompare(instance, value))) {
-          errors.add(new OutputUnit(instanceLocation, "enum", schemaLocation + "/enum", "Instance does not match any of " + Json.encode(schema.get("enum"))));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/enum"), baseLocation + "/enum", "Instance does not match any of " + Json.encode(schema.get("enum"))));
         }
       } else if (schema.<JsonArray>get("enum").stream().noneMatch(value -> Utils.Objects.equals(instance, value))) {
-        errors.add(new OutputUnit(instanceLocation, "enum", schemaLocation + "/enum", "Instance does not match any of " + Json.encode(schema.get("enum"))));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/enum"), baseLocation + "/enum", "Instance does not match any of " + Json.encode(schema.get("enum"))));
       }
     }
 
@@ -209,7 +209,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         new HashSet<>()
       );
       if (result.getValid()) {
-        errors.add(new OutputUnit(instanceLocation, "not", keywordLocation, "Instance matched \"not\" schema"));
+        errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/not"), baseLocation + "/not", "Instance matched \"not\" schema"));
       }
     }
 
@@ -241,7 +241,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       if (anyValid) {
         errors = errors.subList(0, Math.min(errors.size(), errorsLength));
       } else {
-        errors.add(errorsLength, new OutputUnit(instanceLocation, "anyOf", keywordLocation, "Instance does not match any subschemas"));
+        errors.add(errorsLength, new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/anyOf"), baseLocation + "/anyOf", "Instance does not match any subschemas"));
       }
     }
 
@@ -271,7 +271,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       if (allValid) {
         errors = errors.subList(0, Math.min(errors.size(), errorsLength));
       } else {
-        errors.add(errorsLength, new OutputUnit(instanceLocation, "allOf", keywordLocation, "Instance does not match every subschema"));
+        errors.add(errorsLength, new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/allOf"), baseLocation + "/allOf", "Instance does not match every subschema"));
       }
     }
 
@@ -303,7 +303,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       if (matches == 1) {
         errors = errors.subList(0, Math.min(errors.size(), errorsLength));
       } else {
-        errors.add(errorsLength, new OutputUnit(instanceLocation, "oneOf", keywordLocation, "Instance does not match exactly one subschema (" + matches + " matches)"));
+        errors.add(errorsLength, new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/oneOf"), baseLocation + "/oneOf", "Instance does not match exactly one subschema (" + matches + " matches)"));
       }
     }
 
@@ -334,7 +334,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             evaluated
           );
           if (!thenResult.getValid()) {
-            errors.add(new OutputUnit(instanceLocation, "if", keywordLocation, "Instance does not match \"then\" schema"));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/if"), baseLocation + "/if", "Instance does not match \"then\" schema"));
             if (thenResult.getErrors() != null) {
               errors.addAll(thenResult.getErrors());
             }
@@ -351,7 +351,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           evaluated
         );
         if (!elseResult.getValid()) {
-          errors.add(new OutputUnit(instanceLocation, "if", keywordLocation, "Instance does not match \"else\" schema"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/else"), baseLocation + "/else", "Instance does not match \"else\" schema"));
           if (elseResult.getErrors() != null) {
             errors.addAll(elseResult.getErrors());
           }
@@ -364,7 +364,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         if (schema.containsKey("required")) {
           for (final Object key : schema.<JsonArray>get("required")) {
             if (!((JsonObject) instance).containsKey((String) key)) {
-              errors.add(new OutputUnit(instanceLocation, "required", schemaLocation + "/required", "Instance does not have required property \"" + key + "\""));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/required"), baseLocation + "/required", "Instance does not have required property \"" + key + "\""));
             }
           }
         }
@@ -372,11 +372,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         final Set<String> keys = ((JsonObject) instance).fieldNames();
 
         if (schema.containsKey("minProperties") && keys.size() < schema.<Integer>get("minProperties")) {
-          errors.add(new OutputUnit(instanceLocation, "minProperties", schemaLocation + "/minProperties", "Instance does not have at least " + schema.get("minProperties") + " properties"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minProperties"), baseLocation + "/minProperties", "Instance does not have at least " + schema.get("minProperties") + " properties"));
         }
 
         if (schema.containsKey("maxProperties") && keys.size() > schema.<Integer>get("maxProperties")) {
-          errors.add(new OutputUnit(instanceLocation, "maxProperties", schemaLocation + "/maxProperties", "Instance does not have at least " + schema.get("maxProperties") + " properties"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxProperties"), baseLocation + "/maxProperties", "Instance does not have at least " + schema.get("maxProperties") + " properties"));
         }
 
         if (schema.containsKey("propertyNames")) {
@@ -393,7 +393,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               new HashSet<>()
             );
             if (!result.getValid()) {
-              errors.add(new OutputUnit(instanceLocation, "propertyNames", keywordLocation, "Property name \"" + key + "\" does not match schema"));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/propertyNames"), baseLocation + "/propertyNames", "Property name \"" + key + "\" does not match schema"));
               if (result.getErrors() != null) {
                 errors.addAll(result.getErrors());
               }
@@ -408,7 +408,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               final JsonArray required = schema.<JsonObject>get("dependentRequired").getJsonArray(key);
               for (final Object dependantKey : required) {
                 if (!(((JsonObject) instance).containsKey((String) dependantKey))) {
-                  errors.add(new OutputUnit(instanceLocation, "dependentRequired", keywordLocation, "Instance has \"" + key + "\" but does not have \"" + dependantKey + "\""));
+                  errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/dependentRequired"), baseLocation + "/dependentRequired", "Instance has \"" + key + "\" but does not have \"" + dependantKey + "\""));
                 }
               }
             }
@@ -429,7 +429,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 evaluated
               );
               if (!result.getValid()) {
-                errors.add(new OutputUnit(instanceLocation, "dependentSchemas", keywordLocation, "Instance has \"" + key + "\" but does not match dependant schema"));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/dependentSchemas"), baseLocation + "/dependentSchemas", "Instance has \"" + key + "\" but does not match dependant schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -446,7 +446,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               if (propsOrSchema instanceof JsonArray) {
                 for (final Object dependantKey : ((JsonArray) propsOrSchema)) {
                   if (!((JsonObject) instance).containsKey((String) dependantKey)) {
-                    errors.add(new OutputUnit(instanceLocation, "dependencies", keywordLocation, "Instance has \"" + key + "\" but does not have \"" + dependantKey + "\""));
+                    errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/dependencies"), baseLocation + "/dependencies", "Instance has \"" + key + "\" but does not have \"" + dependantKey + "\""));
                   }
                 }
               } else {
@@ -460,7 +460,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                   new HashSet<>()
                 );
                 if (!result.getValid()) {
-                  errors.add(new OutputUnit(instanceLocation, "dependencies", keywordLocation, "Instance has \"" + key + "\" but does not match dependant schema"));
+                  errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/dependencies"), baseLocation + "/dependencies", "Instance has \"" + key + "\" but does not match dependant schema"));
                   if (result.getErrors() != null) {
                     errors.addAll(result.getErrors());
                   }
@@ -495,7 +495,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               thisEvaluated.add(key);
             } else {
               stop = outputFormat == OutputFormat.Flag;
-              errors.add(new OutputUnit(instanceLocation, "properties", keywordLocation, "Property \"" + key + "\" does not match schema"));
+              errors.add(new OutputUnit(subInstancePointer, computeAbsoluteKeywordLocation(schema, schemaLocation + "/properties"), baseLocation + "/properties", "Property \"" + key + "\" does not match schema"));
               if (result.getErrors() != null) {
                 errors.addAll(result.getErrors());
               }
@@ -529,7 +529,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 thisEvaluated.add(key);
               } else {
                 stop = outputFormat == OutputFormat.Flag;
-                errors.add(new OutputUnit(instanceLocation, "patternProperties", keywordLocation, "Property \"" + key + "\" matches pattern \"" + pattern + "\" but does not match associated schema"));
+                errors.add(new OutputUnit(subInstancePointer, computeAbsoluteKeywordLocation(schema, schemaLocation + "/patternProperties"), baseLocation + "/patternProperties", "Property \"" + key + "\" matches pattern \"" + pattern + "\" but does not match associated schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -558,9 +558,12 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               evaluated.add(key);
             } else {
               stop = outputFormat == OutputFormat.Flag;
-              errors.add(new OutputUnit(instanceLocation, "additionalProperties", keywordLocation, "Property \"" + key + "\" does not match additional properties schema"));
+              errors.add(new OutputUnit(subInstancePointer, computeAbsoluteKeywordLocation(schema, schemaLocation + "/additionalProperties"), baseLocation + "/additionalProperties", "Property \"" + key + "\" does not match additional properties schema"));
               if (result.getErrors() != null) {
                 errors.addAll(result.getErrors());
+              }
+              if (stop) {
+                break;
               }
             }
           }
@@ -581,7 +584,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               if (result.getValid()) {
                 evaluated.add(key);
               } else {
-                errors.add(new OutputUnit(instanceLocation, "unevaluatedProperties", keywordLocation, "Property \"" + key + "\" does not match unevaluated properties schema"));
+                errors.add(new OutputUnit(subInstancePointer, computeAbsoluteKeywordLocation(schema, schemaLocation + "/unevaluatedProperties"), baseLocation + "/unevaluatedProperties", "Property \"" + key + "\" does not match unevaluated properties schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -593,11 +596,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       }
       case "array": {
         if (schema.containsKey("maxItems") && ((JsonArray) instance).size() > schema.<Integer>get("maxItems")) {
-          errors.add(new OutputUnit(instanceLocation, "maxItems", schemaLocation + "/maxItems", "Array has too many items ( + " + ((JsonArray) instance).size() + " > " + schema.get("maxItems") + ")"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxItems"), baseLocation + "/maxItems", "Array has too many items ( + " + ((JsonArray) instance).size() + " > " + schema.get("maxItems") + ")"));
         }
 
         if (schema.containsKey("minItems") && ((JsonArray) instance).size() < schema.<Integer>get("minItems")) {
-          errors.add(new OutputUnit(instanceLocation, "minItems", schemaLocation + "/minItems", "Array has too few items ( + " + ((JsonArray) instance).size() + " < " + schema.get("minItems") + ")"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minItems"), baseLocation + "/minItems", "Array has too few items ( + " + ((JsonArray) instance).size() + " < " + schema.get("minItems") + ")"));
         }
 
         final int length = ((JsonArray) instance).size();
@@ -620,7 +623,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             evaluated.add(i);
             if (!result.getValid()) {
               stop = outputFormat == OutputFormat.Flag;
-              errors.add(new OutputUnit(instanceLocation, "prefixItems", keywordLocation, "Items did not match schema"));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/prefixItems"), baseLocation + "/prefixItems", "Items did not match schema"));
               if (result.getErrors() != null) {
                 errors.addAll(result.getErrors());
               }
@@ -648,7 +651,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               evaluated.add(i);
               if (!result.getValid()) {
                 stop = outputFormat == OutputFormat.Flag;
-                errors.add(new OutputUnit(instanceLocation, "items", keywordLocation, "Items did not match schema"));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/items"), baseLocation + "/items", "Items did not match schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -671,7 +674,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               evaluated.add(i);
               if (!result.getValid()) {
                 stop = outputFormat == OutputFormat.Flag;
-                errors.add(new OutputUnit(instanceLocation, "items", keywordLocation, "Items did not match schema"));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/items"), baseLocation + "/items", "Items did not match schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -697,7 +700,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               evaluated.add(i);
               if (!result.getValid()) {
                 stop = outputFormat == OutputFormat.Flag;
-                errors.add(new OutputUnit(instanceLocation, "additionalItems", keywordLocation2, "Items did not match additional items schema"));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/additionalItems"), schemaLocation + "/additionalItems", "Items did not match additional items schema"));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -708,9 +711,9 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
 
         if (schema.containsKey("contains")) {
           if (length == 0 && !schema.containsKey("minContains")) {
-            errors.add(new OutputUnit(instanceLocation, "contains", schemaLocation + "/contains", "Array is empty. It must contain at least one item matching the schema"));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contains"), baseLocation + "/contains", "Array is empty. It must contain at least one item matching the schema"));
           } else if (schema.containsKey("minContains") && length < schema.<Integer>get("minContains")) {
-            errors.add(new OutputUnit(instanceLocation, "minContains", schemaLocation + "/minContains", "Array has less items (" + length + ") than minContains (" + schema.get("minContains") + ")"));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array has less items (" + length + ") than minContains (" + schema.get("minContains") + ")"));
           } else {
             final String keywordLocation = schemaLocation + "/contains";
             final int errorsLength = errors.size();
@@ -744,11 +747,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 !schema.containsKey("maxContains") &&
                 contained == 0
             ) {
-              errors.add(errorsLength, new OutputUnit(instanceLocation, "contains", keywordLocation, "Array does not contain item matching schema"));
+              errors.add(errorsLength, new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contains"), baseLocation + "/contains", "Array does not contain item matching schema"));
             } else if (schema.containsKey("minContains") && contained < schema.<Integer>get("minContains")) {
-              errors.add(new OutputUnit(instanceLocation, "minContains", keywordLocation + "/minContains", "Array must contain at least " + schema.get("minContains") + " items matching schema. Only " + contained + " items were found"));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array must contain at least " + schema.get("minContains") + " items matching schema. Only " + contained + " items were found"));
             } else if (schema.containsKey("maxContains") && contained > schema.<Integer>get("maxContains")) {
-              errors.add(new OutputUnit(instanceLocation, "maxContains", keywordLocation + "/maxContains", "Array may contain at most " + schema.get("minContains") + " items matching schema. " + contained + " items were found"));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxContains"), baseLocation + "/maxContains", "Array may contain at most " + schema.get("minContains") + " items matching schema. " + contained + " items were found"));
             }
           }
         }
@@ -770,7 +773,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             );
             evaluated.add(i);
             if (!result.getValid()) {
-              errors.add(new OutputUnit(instanceLocation, "unevaluatedItems", keywordLocation, "Items did not match unevaluated items schema"));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/unevaluatedItems"), baseLocation + "/unevaluatedItems", "Items did not match unevaluated items schema"));
               if (result.getErrors() != null) {
                 errors.addAll(result.getErrors());
               }
@@ -790,7 +793,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               final Object b = ((JsonArray) instance).getValue(k);
               final boolean bo = "object".equals(JSON.typeOf(b)) && b != null;
               if (Utils.Objects.equals(a, b) || (ao && bo && JSON.deepCompare(a, b))) {
-                errors.add(new OutputUnit(instanceLocation, "uniqueItems", schemaLocation + "/uniqueItems", "Duplicate items at indexes " + j + " and " + k));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/uniqueItems"), baseLocation + "/uniqueItems", "Duplicate items at indexes " + j + " and " + k));
                 break outer;
               }
             }
@@ -805,27 +808,27 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               ((schema.<Boolean>get("exclusiveMinimum", false) && Numbers.lte((Number) instance, schema.get("minimum"))) ||
                 Numbers.lt((Number) instance, schema.get("minimum")))
           ) {
-            errors.add(new OutputUnit(instanceLocation, "minimum", schemaLocation + "/minimum", instance + " is less than " + (schema.<Boolean>get("exclusiveMinimum", false) ? "or equal to " : "") + schema.get("minimum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minimum"), baseLocation + "/minimum", instance + " is less than " + (schema.<Boolean>get("exclusiveMinimum", false) ? "or equal to " : "") + schema.get("minimum")));
           }
           if (
             schema.containsKey("maximum") &&
               ((schema.<Boolean>get("exclusiveMaximum", false) && Numbers.gte((Number) instance, schema.get("maximum"))) ||
                 Numbers.gt((Number) instance, schema.get("maximum")))
           ) {
-            errors.add(new OutputUnit(instanceLocation, "maximum", schemaLocation + "/maximum", instance + " is greater than " + (schema.<Boolean>get("exclusiveMaximum", false) ? "or equal to " : "") + schema.get("maximum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maximum"), baseLocation + "/maximum", instance + " is greater than " + (schema.<Boolean>get("exclusiveMaximum", false) ? "or equal to " : "") + schema.get("maximum")));
           }
         } else {
           if (schema.containsKey("minimum") && Numbers.lt((Number) instance, schema.get("minimum"))) {
-            errors.add(new OutputUnit(instanceLocation, "minimum", schemaLocation + "/minimum", instance + " is less than " + schema.get("minimum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minimum"), baseLocation + "/minimum", instance + " is less than " + schema.get("minimum")));
           }
           if (schema.containsKey("maximum") && Numbers.gt((Number) instance, schema.get("maximum"))) {
-            errors.add(new OutputUnit(instanceLocation, "maximum", schemaLocation + "/maximum", instance + " is greater than " + schema.get("maximum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maximum"), baseLocation + "/maximum", instance + " is greater than " + schema.get("maximum")));
           }
           if (schema.containsKey("exclusiveMinimum") && Numbers.lte((Number) instance, schema.get("exclusiveMinimum"))) {
-            errors.add(new OutputUnit(instanceLocation, "exclusiveMinimum", schemaLocation + "/exclusiveMinimum", instance + " is less than or equal to " + schema.get("exclusiveMinimum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/exclusiveMinimum"), baseLocation + "/exclusiveMinimum", instance + " is less than or equal to " + schema.get("exclusiveMinimum")));
           }
           if (schema.containsKey("exclusiveMaximum") && Numbers.gte((Number) instance, schema.get("exclusiveMaximum"))) {
-            errors.add(new OutputUnit(instanceLocation, "exclusiveMaximum", schemaLocation + "/exclusiveMaximum", instance + " is greater than or equal to " + schema.get("exclusiveMaximum")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/exclusiveMaximum"), baseLocation + "/exclusiveMaximum", instance + " is greater than or equal to " + schema.get("exclusiveMaximum")));
           }
         }
         if (schema.containsKey("multipleOf")) {
@@ -834,7 +837,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             Math.abs(0 - remainder) >= 1.1920929e-7 &&
               Math.abs(schema.<Number>get("multipleOf").doubleValue() - remainder) >= 1.1920929e-7
           ) {
-            errors.add(new OutputUnit(instanceLocation, "multipleOf", schemaLocation + "/multipleOf", instance + " is not a multiple of " + schema.get("multipleOf")));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/multipleOf"), baseLocation + "/multipleOf", instance + " is not a multiple of " + schema.get("multipleOf")));
           }
         }
         break;
@@ -844,13 +847,13 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             ? 0
             : Strings.ucs2length((String) instance);
         if (schema.containsKey("minLength") && Numbers.lt(length, schema.get("minLength"))) {
-          errors.add(new OutputUnit(instanceLocation, "minLength", schemaLocation + "/minLength", "String is too short (" + length + " < " + schema.get("minLength") + ")"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minLength"), baseLocation + "/minLength", "String is too short (" + length + " < " + schema.get("minLength") + ")"));
         }
         if (schema.containsKey("maxLength") && Numbers.gt(length, schema.get("maxLength"))) {
-          errors.add(new OutputUnit(instanceLocation, "maxLength", schemaLocation + "/maxLength", "String is too long (" + length + " > " + schema.get("maxLength") + ")"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxLength"), baseLocation + "/maxLength", "String is too long (" + length + " > " + schema.get("maxLength") + ")"));
         }
         if (schema.containsKey("pattern") && !Pattern.compile(schema.get("pattern")).matcher((String) instance).find()) {
-          errors.add(new OutputUnit(instanceLocation, "pattern", schemaLocation + "/pattern", "String does not match pattern"));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/pattern"), baseLocation + "/pattern", "String does not match pattern"));
         }
         if (
           schema.containsKey("format") &&
@@ -862,7 +865,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
 //              annotations.add(new OutputUnit(instanceLocation, "format", schemaLocation + "/format", "String does not match format \"" + schema.get("format") + "\""));
 //              break;
 //            default:
-              errors.add(new OutputUnit(instanceLocation, "format", schemaLocation + "/format", "String does not match format \"" + schema.get("format") + "\""));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/format"), baseLocation + "/format", "String does not match format \"" + schema.get("format") + "\""));
 //          }
         }
         break;
@@ -872,5 +875,19 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
     return new OutputUnit(errors.isEmpty())
       .setErrors(outputFormat == OutputFormat.Flag ? null : errors.isEmpty() ? null : errors)
       .setAnnotations(outputFormat == OutputFormat.Flag ? null : annotations.isEmpty() ? null : annotations);
+  }
+
+  private String computeAbsoluteKeywordLocation(JsonSchema schema, String schemaKeywordLocation) {
+    if (schemaKeywordLocation == null) {
+      return null;
+    }
+
+    final String absoluteUri = schema.get("__absolute_uri__");
+
+    if (absoluteUri == null) {
+      return null;
+    }
+
+    return new URL(schemaKeywordLocation, absoluteUri).href();
   }
 }

--- a/src/test/java/io/vertx/json/schema/OutputUnitTest.java
+++ b/src/test/java/io/vertx/json/schema/OutputUnitTest.java
@@ -29,55 +29,55 @@ class OutputUnitTest {
     }
   }
 
-//  @Test
-//  public void testBasicMode() {
-//    OutputUnit outputUnit = new OutputUnit(new JsonObject(
-//      "{\n" +
-//        "  \"valid\": false,\n" +
-//        "  \"errors\": [\n" +
-//        "    {\n" +
-//        "      \"keywordLocation\": \"\",\n" +
-//        "      \"instanceLocation\": \"\",\n" +
-//        "      \"error\": \"A subschema had errors.\"\n" +
-//        "    },\n" +
-//        "    {\n" +
-//        "      \"keywordLocation\": \"/items/$ref\",\n" +
-//        "      \"absoluteKeywordLocation\":\n" +
-//        "        \"https://example.com/polygon#/$defs/point\",\n" +
-//        "      \"instanceLocation\": \"/1\",\n" +
-//        "      \"error\": \"A subschema had errors.\"\n" +
-//        "    },\n" +
-//        "    {\n" +
-//        "      \"keywordLocation\": \"/items/$ref/required\",\n" +
-//        "      \"absoluteKeywordLocation\":\n" +
-//        "        \"https://example.com/polygon#/$defs/point/required\",\n" +
-//        "      \"instanceLocation\": \"/1\",\n" +
-//        "      \"error\": \"Required property 'y' not found.\"\n" +
-//        "    },\n" +
-//        "    {\n" +
-//        "      \"keywordLocation\": \"/items/$ref/additionalProperties\",\n" +
-//        "      \"absoluteKeywordLocation\":\n" +
-//        "        \"https://example.com/polygon#/$defs/point/additionalProperties\",\n" +
-//        "      \"instanceLocation\": \"/1/z\",\n" +
-//        "      \"error\": \"Additional property 'z' found but was invalid.\"\n" +
-//        "    },\n" +
-//        "    {\n" +
-//        "      \"keywordLocation\": \"/minItems\",\n" +
-//        "      \"instanceLocation\": \"\",\n" +
-//        "      \"error\": \"Expected at least 3 items but found 2\"\n" +
-//        "    }\n" +
-//        "  ]\n" +
-//        "}"
-//    ));
-//    try {
-//      outputUnit.checkValidity();
-//      fail("Should not reach here");
-//    } catch (JsonSchemaValidationException e) {
-//      assertEquals("Expected at least 3 items but found 2", e.getMessage());
-//      assertNull(e.location());
-//    }
-//  }
-//
+  @Test
+  public void testBasicMode() {
+    OutputUnit outputUnit = new OutputUnit(new JsonObject(
+      "{\n" +
+        "  \"valid\": false,\n" +
+        "  \"errors\": [\n" +
+        "    {\n" +
+        "      \"keywordLocation\": \"\",\n" +
+        "      \"instanceLocation\": \"\",\n" +
+        "      \"error\": \"A subschema had errors.\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"keywordLocation\": \"/items/$ref\",\n" +
+        "      \"absoluteKeywordLocation\":\n" +
+        "        \"https://example.com/polygon#/$defs/point\",\n" +
+        "      \"instanceLocation\": \"/1\",\n" +
+        "      \"error\": \"A subschema had errors.\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"keywordLocation\": \"/items/$ref/required\",\n" +
+        "      \"absoluteKeywordLocation\":\n" +
+        "        \"https://example.com/polygon#/$defs/point/required\",\n" +
+        "      \"instanceLocation\": \"/1\",\n" +
+        "      \"error\": \"Required property 'y' not found.\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"keywordLocation\": \"/items/$ref/additionalProperties\",\n" +
+        "      \"absoluteKeywordLocation\":\n" +
+        "        \"https://example.com/polygon#/$defs/point/additionalProperties\",\n" +
+        "      \"instanceLocation\": \"/1/z\",\n" +
+        "      \"error\": \"Additional property 'z' found but was invalid.\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"keywordLocation\": \"/minItems\",\n" +
+        "      \"instanceLocation\": \"\",\n" +
+        "      \"error\": \"Expected at least 3 items but found 2\"\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}"
+    ));
+    try {
+      outputUnit.checkValidity();
+      fail("Should not reach here");
+    } catch (JsonSchemaValidationException e) {
+      assertEquals("Expected at least 3 items but found 2", e.getMessage());
+      assertNull(e.location());
+    }
+  }
+
   @Test
   public void testSpecFlag() {
     JsonSchema schema = JsonSchema.of(new JsonObject(

--- a/src/test/java/io/vertx/json/schema/OutputUnitTest.java
+++ b/src/test/java/io/vertx/json/schema/OutputUnitTest.java
@@ -125,51 +125,59 @@ class OutputUnitTest {
     assertNull(result.getErrors());
   }
 
-//  @Test
-//  public void testSpecBasic() {
-//    JsonSchema schema = JsonSchema.of(new JsonObject(
-//      "{\n" +
-//        "  \"$id\": \"https://example.com/polygon\",\n" +
-//        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
-//        "  \"$defs\": {\n" +
-//        "    \"point\": {\n" +
-//        "      \"type\": \"object\",\n" +
-//        "      \"properties\": {\n" +
-//        "        \"x\": { \"type\": \"number\" },\n" +
-//        "        \"y\": { \"type\": \"number\" }\n" +
-//        "      },\n" +
-//        "      \"additionalProperties\": false,\n" +
-//        "      \"required\": [ \"x\", \"y\" ]\n" +
-//        "    }\n" +
-//        "  },\n" +
-//        "  \"type\": \"array\",\n" +
-//        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
-//        "  \"minItems\": 3\n" +
-//        "}"));
-//
-//    Validator validator = Validator.create(
-//      schema,
-//      new JsonSchemaOptions()
-//        .setDraft(Draft.DRAFT202012)
-//        .setBaseUri("urn:")
-//        .setOutputFormat(OutputFormat.Basic));
-//
-//    JsonArray input = new JsonArray(
-//      "[\n" +
-//        "  {\n" +
-//        "    \"x\": 2.5,\n" +
-//        "    \"y\": 1.3\n" +
-//        "  },\n" +
-//        "  {\n" +
-//        "    \"x\": 1,\n" +
-//        "    \"z\": 6.7\n" +
-//        "  }\n" +
-//        "]");
-//
-//    OutputUnit result = validator.validate(input);
-//
-//    assertFalse(result.getValid());
-//    System.out.println(result.toJson().encodePrettily());
-//    assertEquals(5, result.getErrors().size());
-//  }
+  @Test
+  public void testSpecBasic() {
+    JsonSchema schema = JsonSchema.of(new JsonObject(
+      "{\n" +
+        "  \"$id\": \"https://example.com/polygon\",\n" +
+        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+        "  \"$defs\": {\n" +
+        "    \"point\": {\n" +
+        "      \"type\": \"object\",\n" +
+        "      \"properties\": {\n" +
+        "        \"x\": { \"type\": \"number\" },\n" +
+        "        \"y\": { \"type\": \"number\" }\n" +
+        "      },\n" +
+        "      \"additionalProperties\": false,\n" +
+        "      \"required\": [ \"x\", \"y\" ]\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"type\": \"array\",\n" +
+        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
+        "  \"minItems\": 3\n" +
+        "}"));
+
+    Validator validator = Validator.create(
+      schema,
+      new JsonSchemaOptions()
+        .setDraft(Draft.DRAFT202012)
+        .setBaseUri("urn:")
+        .setOutputFormat(OutputFormat.Basic));
+
+    JsonArray input = new JsonArray(
+      "[\n" +
+        "  {\n" +
+        "    \"x\": 2.5,\n" +
+        "    \"y\": 1.3\n" +
+        "  },\n" +
+        "  {\n" +
+        "    \"x\": 1,\n" +
+        "    \"z\": 6.7\n" +
+        "  }\n" +
+        "]");
+
+    OutputUnit result = validator.validate(input);
+
+    assertFalse(result.getValid());
+    try {
+      result.checkValidity();
+    } catch (JsonSchemaValidationException e) {
+      // TODO: should we have a location here? I think it's due to the fact that we have 1 extra entry (Boolean Schema)
+      // assertNotNull(e.location());
+      e.printStackTrace();
+    }
+    // TODO: according to the spec the boolean entry is superfluos, yet it doesn't affect the result
+    // needs fix
+    //assertEquals(5, result.getErrors().size());
+  }
 }

--- a/src/test/java/io/vertx/json/schema/OutputUnitTest.java
+++ b/src/test/java/io/vertx/json/schema/OutputUnitTest.java
@@ -1,0 +1,175 @@
+package io.vertx.json.schema;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OutputUnitTest {
+
+  @Test
+  public void testFlagModeInvalid() {
+    OutputUnit outputUnit = new OutputUnit(new JsonObject().put("valid", false));
+    try {
+      outputUnit.checkValidity();
+      fail("Should not reach here");
+    } catch (JsonSchemaValidationException e) {
+      assertEquals("JsonSchema Validation error", e.getMessage());
+      assertNull(e.location());
+    }
+  }
+  @Test
+  public void testFlagModeValid() {
+    OutputUnit outputUnit = new OutputUnit(new JsonObject().put("valid", true));
+    try {
+      outputUnit.checkValidity();
+    } catch (JsonSchemaValidationException e) {
+      fail("Should not reach here");
+    }
+  }
+
+//  @Test
+//  public void testBasicMode() {
+//    OutputUnit outputUnit = new OutputUnit(new JsonObject(
+//      "{\n" +
+//        "  \"valid\": false,\n" +
+//        "  \"errors\": [\n" +
+//        "    {\n" +
+//        "      \"keywordLocation\": \"\",\n" +
+//        "      \"instanceLocation\": \"\",\n" +
+//        "      \"error\": \"A subschema had errors.\"\n" +
+//        "    },\n" +
+//        "    {\n" +
+//        "      \"keywordLocation\": \"/items/$ref\",\n" +
+//        "      \"absoluteKeywordLocation\":\n" +
+//        "        \"https://example.com/polygon#/$defs/point\",\n" +
+//        "      \"instanceLocation\": \"/1\",\n" +
+//        "      \"error\": \"A subschema had errors.\"\n" +
+//        "    },\n" +
+//        "    {\n" +
+//        "      \"keywordLocation\": \"/items/$ref/required\",\n" +
+//        "      \"absoluteKeywordLocation\":\n" +
+//        "        \"https://example.com/polygon#/$defs/point/required\",\n" +
+//        "      \"instanceLocation\": \"/1\",\n" +
+//        "      \"error\": \"Required property 'y' not found.\"\n" +
+//        "    },\n" +
+//        "    {\n" +
+//        "      \"keywordLocation\": \"/items/$ref/additionalProperties\",\n" +
+//        "      \"absoluteKeywordLocation\":\n" +
+//        "        \"https://example.com/polygon#/$defs/point/additionalProperties\",\n" +
+//        "      \"instanceLocation\": \"/1/z\",\n" +
+//        "      \"error\": \"Additional property 'z' found but was invalid.\"\n" +
+//        "    },\n" +
+//        "    {\n" +
+//        "      \"keywordLocation\": \"/minItems\",\n" +
+//        "      \"instanceLocation\": \"\",\n" +
+//        "      \"error\": \"Expected at least 3 items but found 2\"\n" +
+//        "    }\n" +
+//        "  ]\n" +
+//        "}"
+//    ));
+//    try {
+//      outputUnit.checkValidity();
+//      fail("Should not reach here");
+//    } catch (JsonSchemaValidationException e) {
+//      assertEquals("Expected at least 3 items but found 2", e.getMessage());
+//      assertNull(e.location());
+//    }
+//  }
+//
+//  @Test
+//  public void testSpecFlag() {
+//    JsonSchema schema = JsonSchema.of(new JsonObject(
+//      "{\n" +
+//        "  \"$id\": \"https://example.com/polygon\",\n" +
+//        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+//        "  \"$defs\": {\n" +
+//        "    \"point\": {\n" +
+//        "      \"type\": \"object\",\n" +
+//        "      \"properties\": {\n" +
+//        "        \"x\": { \"type\": \"number\" },\n" +
+//        "        \"y\": { \"type\": \"number\" }\n" +
+//        "      },\n" +
+//        "      \"additionalProperties\": false,\n" +
+//        "      \"required\": [ \"x\", \"y\" ]\n" +
+//        "    }\n" +
+//        "  },\n" +
+//        "  \"type\": \"array\",\n" +
+//        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
+//        "  \"minItems\": 3\n" +
+//        "}"));
+//
+//    Validator validator = Validator.create(
+//      schema,
+//      new JsonSchemaOptions()
+//        .setDraft(Draft.DRAFT202012)
+//        .setBaseUri("urn:")
+//        .setOutputFormat(OutputFormat.Flag));
+//
+//    JsonArray input = new JsonArray(
+//      "[\n" +
+//        "  {\n" +
+//        "    \"x\": 2.5,\n" +
+//        "    \"y\": 1.3\n" +
+//        "  },\n" +
+//        "  {\n" +
+//        "    \"x\": 1,\n" +
+//        "    \"z\": 6.7\n" +
+//        "  }\n" +
+//        "]");
+//
+//    OutputUnit result = validator.validate(input);
+//
+//    assertFalse(result.getValid());
+//    assertEquals(0, result.getErrors().size());
+//  }
+//
+//  @Test
+//  public void testSpecBasic() {
+//    JsonSchema schema = JsonSchema.of(new JsonObject(
+//      "{\n" +
+//        "  \"$id\": \"https://example.com/polygon\",\n" +
+//        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+//        "  \"$defs\": {\n" +
+//        "    \"point\": {\n" +
+//        "      \"type\": \"object\",\n" +
+//        "      \"properties\": {\n" +
+//        "        \"x\": { \"type\": \"number\" },\n" +
+//        "        \"y\": { \"type\": \"number\" }\n" +
+//        "      },\n" +
+//        "      \"additionalProperties\": false,\n" +
+//        "      \"required\": [ \"x\", \"y\" ]\n" +
+//        "    }\n" +
+//        "  },\n" +
+//        "  \"type\": \"array\",\n" +
+//        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
+//        "  \"minItems\": 3\n" +
+//        "}"));
+//
+//    Validator validator = Validator.create(
+//      schema,
+//      new JsonSchemaOptions()
+//        .setDraft(Draft.DRAFT202012)
+//        .setBaseUri("urn:")
+//        .setOutputFormat(OutputFormat.Basic));
+//
+//    JsonArray input = new JsonArray(
+//      "[\n" +
+//        "  {\n" +
+//        "    \"x\": 2.5,\n" +
+//        "    \"y\": 1.3\n" +
+//        "  },\n" +
+//        "  {\n" +
+//        "    \"x\": 1,\n" +
+//        "    \"z\": 6.7\n" +
+//        "  }\n" +
+//        "]");
+//
+//    OutputUnit result = validator.validate(input);
+//
+//    assertFalse(result.getValid());
+//    System.out.println(result.toJson().encodePrettily());
+//    assertEquals(5, result.getErrors().size());
+//  }
+}

--- a/src/test/java/io/vertx/json/schema/OutputUnitTest.java
+++ b/src/test/java/io/vertx/json/schema/OutputUnitTest.java
@@ -172,12 +172,8 @@ class OutputUnitTest {
     try {
       result.checkValidity();
     } catch (JsonSchemaValidationException e) {
-      // TODO: should we have a location here? I think it's due to the fact that we have 1 extra entry (Boolean Schema)
-      // assertNotNull(e.location());
-      e.printStackTrace();
+      assertNotNull(e.location());
     }
-    // TODO: according to the spec the boolean entry is superfluos, yet it doesn't affect the result
-    // needs fix
-    //assertEquals(5, result.getErrors().size());
+    assertEquals(5, result.getErrors().size());
   }
 }

--- a/src/test/java/io/vertx/json/schema/OutputUnitTest.java
+++ b/src/test/java/io/vertx/json/schema/OutputUnitTest.java
@@ -78,53 +78,53 @@ class OutputUnitTest {
 //    }
 //  }
 //
-//  @Test
-//  public void testSpecFlag() {
-//    JsonSchema schema = JsonSchema.of(new JsonObject(
-//      "{\n" +
-//        "  \"$id\": \"https://example.com/polygon\",\n" +
-//        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
-//        "  \"$defs\": {\n" +
-//        "    \"point\": {\n" +
-//        "      \"type\": \"object\",\n" +
-//        "      \"properties\": {\n" +
-//        "        \"x\": { \"type\": \"number\" },\n" +
-//        "        \"y\": { \"type\": \"number\" }\n" +
-//        "      },\n" +
-//        "      \"additionalProperties\": false,\n" +
-//        "      \"required\": [ \"x\", \"y\" ]\n" +
-//        "    }\n" +
-//        "  },\n" +
-//        "  \"type\": \"array\",\n" +
-//        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
-//        "  \"minItems\": 3\n" +
-//        "}"));
-//
-//    Validator validator = Validator.create(
-//      schema,
-//      new JsonSchemaOptions()
-//        .setDraft(Draft.DRAFT202012)
-//        .setBaseUri("urn:")
-//        .setOutputFormat(OutputFormat.Flag));
-//
-//    JsonArray input = new JsonArray(
-//      "[\n" +
-//        "  {\n" +
-//        "    \"x\": 2.5,\n" +
-//        "    \"y\": 1.3\n" +
-//        "  },\n" +
-//        "  {\n" +
-//        "    \"x\": 1,\n" +
-//        "    \"z\": 6.7\n" +
-//        "  }\n" +
-//        "]");
-//
-//    OutputUnit result = validator.validate(input);
-//
-//    assertFalse(result.getValid());
-//    assertEquals(0, result.getErrors().size());
-//  }
-//
+  @Test
+  public void testSpecFlag() {
+    JsonSchema schema = JsonSchema.of(new JsonObject(
+      "{\n" +
+        "  \"$id\": \"https://example.com/polygon\",\n" +
+        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+        "  \"$defs\": {\n" +
+        "    \"point\": {\n" +
+        "      \"type\": \"object\",\n" +
+        "      \"properties\": {\n" +
+        "        \"x\": { \"type\": \"number\" },\n" +
+        "        \"y\": { \"type\": \"number\" }\n" +
+        "      },\n" +
+        "      \"additionalProperties\": false,\n" +
+        "      \"required\": [ \"x\", \"y\" ]\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"type\": \"array\",\n" +
+        "  \"items\": { \"$ref\": \"#/$defs/point\" },\n" +
+        "  \"minItems\": 3\n" +
+        "}"));
+
+    Validator validator = Validator.create(
+      schema,
+      new JsonSchemaOptions()
+        .setDraft(Draft.DRAFT202012)
+        .setBaseUri("urn:")
+        .setOutputFormat(OutputFormat.Flag));
+
+    JsonArray input = new JsonArray(
+      "[\n" +
+        "  {\n" +
+        "    \"x\": 2.5,\n" +
+        "    \"y\": 1.3\n" +
+        "  },\n" +
+        "  {\n" +
+        "    \"x\": 1,\n" +
+        "    \"z\": 6.7\n" +
+        "  }\n" +
+        "]");
+
+    OutputUnit result = validator.validate(input);
+
+    assertFalse(result.getValid());
+    assertNull(result.getErrors());
+  }
+
 //  @Test
 //  public void testSpecBasic() {
 //    JsonSchema schema = JsonSchema.of(new JsonObject(


### PR DESCRIPTION
Motivation:

Output unit is quite powerful as defined in the spec, however is doesn't feel natural in java. For this, we introduce a new method: `checkValidity()` that, like in other JDK places, will throw a typed exception with information about the location where the error happened and as stack trace the jumps the parser did until the error.