### PR TITLE
Reproducer/resolve circular with combinator

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/CircularReferenceException.java
+++ b/src/main/java/io/vertx/json/schema/impl/CircularReferenceException.java
@@ -1,0 +1,8 @@
+package io.vertx.json.schema.impl;
+
+
+public class CircularReferenceException extends RuntimeException {
+  public CircularReferenceException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/io/vertx/json/schema/ResolverTest.java
+++ b/src/test/java/io/vertx/json/schema/ResolverTest.java
@@ -33,17 +33,8 @@ public class ResolverTest {
 
     JsonObject res = schema.resolve();
 
-    JsonObject ptr = res.getJsonObject("properties").getJsonObject("billing_address").getJsonObject("properties");
-    assertThat(ptr.getJsonObject("city").getString("type"))
-      .isEqualTo("string");
-
-    // circular check
-    JsonObject circular = ptr.getJsonObject("subAddress");
-    assertThat(circular.getString("$ref")).isEqualTo("http://www.example.com/#/definitions/address");
-
-    // array checks
-    assertThat(res.getJsonArray("required").getString(0))
-      .isEqualTo("billing_address");
+    JsonObject ptr = res.getJsonObject("properties").getJsonObject("billing_address");
+    assertThat(ptr.getString("$ref")).isNotNull();
 
     assertThat(res.encodePrettily().contains("__absolute_uri")).isFalse();
     assertThat(res.encodePrettily().contains("__absolute_ref")).isFalse();
@@ -59,10 +50,9 @@ public class ResolverTest {
   @Test
   public void testRefResolverFail() throws IOException {
     try {
-      JsonObject res =
-        JsonSchema
-          .of(new JsonObject(Buffer.buffer(Files.readAllBytes(Paths.get("src", "test", "resources", "ref_test", "person_draft201909.json")))))
-          .resolve();
+      JsonSchema
+        .of(new JsonObject(Buffer.buffer(Files.readAllBytes(Paths.get("src", "test", "resources", "ref_test", "person_draft201909.json")))))
+        .resolve();
 
       fail("Should not reach here");
     } catch (SchemaException e) {

--- a/src/test/java/io/vertx/json/schema/ResolverTest.java
+++ b/src/test/java/io/vertx/json/schema/ResolverTest.java
@@ -182,4 +182,17 @@ public class ResolverTest {
     OutputUnit result2 = repo2.validator(schema2).validate(fixture);
     assertThat(result2.getValid()).isTrue();
   }
+
+  @Test
+  void testResolveCircularRefsWithCombinatorKeywords(Vertx vertx) {
+    String path = "resolve/circular_address_anyOf.json";
+    SchemaRepository repo = SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT202012));
+    JsonObject schemaJson = new JsonObject(vertx.fileSystem().readFileBlocking(path));
+    JsonSchema schema = JsonSchema.of(schemaJson.copy());
+    repo.dereference(schema);
+    JsonObject resolved = repo.resolve("http://www.example.com/circular/");
+
+    // There are only circular refs, so it should resolve nothing
+    assertThat(resolved).isEqualTo(schemaJson);
+  }
 }

--- a/src/test/java/io/vertx/json/schema/ResolverTest.java
+++ b/src/test/java/io/vertx/json/schema/ResolverTest.java
@@ -176,7 +176,8 @@ public class ResolverTest {
   @Test
   void testResolveCircularRefsWithCombinatorKeywords(Vertx vertx) {
     String path = "resolve/circular_address_anyOf.json";
-    SchemaRepository repo = SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT202012));
+    SchemaRepository repo =
+      SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT202012));
     JsonObject schemaJson = new JsonObject(vertx.fileSystem().readFileBlocking(path));
     JsonSchema schema = JsonSchema.of(schemaJson.copy());
     repo.dereference(schema);
@@ -184,5 +185,28 @@ public class ResolverTest {
 
     // There are only circular refs, so it should resolve nothing
     assertThat(resolved).isEqualTo(schemaJson);
+  }
+
+  @Test
+  void testResolveCircularRefsWithCombinatorKeywordsComplex(Vertx vertx) {
+    String complexSpec = "resolve/circular/aas_minimal_reproducer.json";
+    String complexMetaModelSpec = "resolve/circular/meta-model/meta_model_minimal.json";
+
+    SchemaRepository repo =
+      SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT202012));
+
+    JsonObject complexSpecSchemaJson = new JsonObject(vertx.fileSystem().readFileBlocking(complexSpec));
+    JsonObject complexMetaModelSpecSchemaJson =
+      new JsonObject(vertx.fileSystem().readFileBlocking(complexMetaModelSpec));
+
+    JsonSchema complexSpecSchema = JsonSchema.of(complexSpecSchemaJson.copy());
+    JsonSchema complexMetaModelSpecSchema = JsonSchema.of(complexMetaModelSpecSchemaJson.copy());
+
+    String metaModelRef = "https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0RC02";
+
+    repo.dereference(metaModelRef, complexMetaModelSpecSchema);
+
+    // Should not fail
+    JsonObject resolved = repo.resolve(complexSpecSchema);
   }
 }

--- a/src/test/resources/resolve/circular/aas_minimal_reproducer.json
+++ b/src/test/resources/resolve/circular/aas_minimal_reproducer.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "V3.0RC02",
+    "title": "DotAAS Part 1 | Metamodel | Schemas",
+    "license": {
+      "identifier": "CC-BY-4.0",
+      "name": "Creative Commons CC-BY-4.0"
+    }
+  },
+  "paths": {
+    "/submodels/{submodelIdentifier}/submodel-elements": {
+      "parameters": [
+        {
+          "name": "submodelIdentifier",
+          "in": "path",
+          "description": "The Submodel’s unique id (UTF8-BASE64-URL-encoded)",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "byte"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Asset Administration Shell Environment API"
+        ],
+        "summary": "Creates a new submodel element",
+        "operationId": "PostSubmodelElement_SubmodelRepo",
+        "requestBody": {
+          "description": "Requested submodel element",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0RC02#/components/schemas/SubmodelElement"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Submodel element created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0RC02#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/resolve/circular/meta-model/meta_model_minimal.json
+++ b/src/test/resources/resolve/circular/meta-model/meta_model_minimal.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "V3.0RC02",
+    "title": "DotAAS Part 1 | Metamodel | Schemas",
+    "license": {
+      "identifier": "CC-BY-4.0",
+      "name": "Creative Commons CC-BY-4.0"
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModelType": {
+        "type": "string",
+        "enum": [
+          "Property",
+          "Submodel",
+          "SubmodelElementCollection"
+        ]
+      },
+      "Property": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractSubmodelElement"
+          },
+          {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Referable": {
+        "allOf": [
+          {
+            "properties": {
+              "modelType": {
+                "$ref": "#/components/schemas/ModelType"
+              }
+            },
+            "required": [
+              "modelType"
+            ]
+          }
+        ]
+      },
+      "Submodel": {
+        "allOf": [
+          {
+            "properties": {
+              "submodelElements": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SubmodelElement"
+                },
+                "minItems": 1
+              }
+            }
+          }
+        ]
+      },
+      "AbstractSubmodelElement": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Referable"
+          }
+        ]
+      },
+      "SubmodelElement": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Property"
+          },
+          {
+            "$ref": "#/components/schemas/SubmodelElementCollection"
+          }
+        ]
+      },
+      "SubmodelElementCollection": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractSubmodelElement"
+          },
+          {
+            "properties": {
+              "value": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SubmodelElement"
+                },
+                "minItems": 1
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/resolve/circular_address_anyOf.json
+++ b/src/test/resources/resolve/circular_address_anyOf.json
@@ -1,0 +1,45 @@
+{
+  "$id": "http://www.example.com/circular/",
+  "definitions": {
+    "addressWithCity": {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "subAddress": {
+          "anyOf": [
+            {
+              "$ref": "http://www.example.com/circular/#/definitions/addressWithCity"
+            }, {
+              "$ref": "http://www.example.com/circular/#/definitions/addressWithState"
+            }
+          ]
+        }
+      }
+    },
+    "addressWithState" : {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "subAddress": {
+          "anyOf": [
+            {
+              "$ref": "http://www.example.com/circular/#/definitions/addressWithCity"
+            }, {
+              "$ref": "http://www.example.com/circular/#/definitions/addressWithState"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Resolution of schemas was not shallow as mentioned in the docs. resolution should not throw on circular references, instead it should stop and return the source schema and log a debug message with the location of the circular dependency.