### PR TITLE
Add support for "duration" string format.

### DIFF
--- a/src/main/java/io/vertx/json/schema/common/RegularExpressions.java
+++ b/src/main/java/io/vertx/json/schema/common/RegularExpressions.java
@@ -26,6 +26,8 @@ public class RegularExpressions {
   public static final Pattern URI = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+-.]*:[^\\s]*$");
   public static final Pattern DATE = Pattern.compile("^\\d{4}-(?:0[0-9]|1[0-2])-[0-9]{2}$");
   public static final Pattern DATETIME = Pattern.compile("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
+
+  public static final Pattern DURATION = Pattern.compile("^(-)?P(?:(?:(-?[0-9,.]*)Y)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)D)?(?:T(?:(-?[0-9,.]*)H)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)S)?)?|(-?[0-9,.]*)W)$");
   public static final Pattern TIME = Pattern.compile("^(?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:[zZ]|[+-]\\d\\d:\\d\\d)?$");
   public static final Pattern BASE64 = Pattern.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$");
   public static final Pattern IPV4 = Pattern.compile("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}" + "" +

--- a/src/main/java/io/vertx/json/schema/draft201909/FormatValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/draft201909/FormatValidatorFactory.java
@@ -25,6 +25,7 @@ public class FormatValidatorFactory extends BaseFormatValidatorFactory {
     predicates.put("byte", createPredicateFromPattern(RegularExpressions.BASE64));
     predicates.put("date", createPredicateFromPattern(RegularExpressions.DATE));
     predicates.put("date-time", createPredicateFromPattern(RegularExpressions.DATETIME));
+    predicates.put("duration", createPredicateFromPattern(RegularExpressions.DURATION));
     predicates.put("ipv4", createPredicateFromPattern(RegularExpressions.IPV4));
     predicates.put("ipv6", createPredicateFromPattern(RegularExpressions.IPV6));
     predicates.put("hostname", createPredicateFromPattern(RegularExpressions.HOSTNAME));

--- a/src/main/java/io/vertx/json/schema/openapi3/FormatValidatorFactory.java
+++ b/src/main/java/io/vertx/json/schema/openapi3/FormatValidatorFactory.java
@@ -34,6 +34,7 @@ public class FormatValidatorFactory extends BaseFormatValidatorFactory {
     predicates.put("byte", createPredicateFromPattern(RegularExpressions.BASE64));
     predicates.put("date", createPredicateFromPattern(RegularExpressions.DATE));
     predicates.put("date-time", createPredicateFromPattern(RegularExpressions.DATETIME));
+    predicates.put("duration", createPredicateFromPattern(RegularExpressions.DURATION));
     predicates.put("ipv4", createPredicateFromPattern(RegularExpressions.IPV4));
     predicates.put("ipv6", createPredicateFromPattern(RegularExpressions.IPV6));
     predicates.put("hostname", createPredicateFromPattern(RegularExpressions.HOSTNAME));

--- a/src/test/java/io/vertx/json/schema/common/RegularExpressionsTest.java
+++ b/src/test/java/io/vertx/json/schema/common/RegularExpressionsTest.java
@@ -1,0 +1,21 @@
+package io.vertx.json.schema.common;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author lcharlois
+ * @since 06/10/2023.
+ */
+class RegularExpressionsTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"P3Y6M4DT12H30M5S","P3DT12H","P1M","PT1M","PT0S","P0.5Y","PT1M3.025S"}) // six numbers
+  void shouldMatchValidDuration(String duration) {
+    assertTrue(RegularExpressions.DURATION.matcher(duration).matches());
+  }
+
+
+}


### PR DESCRIPTION
Fix #116

Motivation:

"duration" format is valid since RFC 2019-09 and in OpenApi 3.0.

