### PR TITLE
fix: validate negative duration strings

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -182,18 +182,18 @@ public class Format {
     return NOT_URI_FRAGMENT.matcher(value).find() && URI_PATTERN.matcher(value).find();
   }
 
-  private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
-  private static final Pattern DURATIION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
-  private static final Pattern DURATIION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
-  private static final Pattern DURATION_D = Pattern.compile("^-?P(-?\\d+([.,]\\d+)?Y)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?W)?(-?\\d+([.,]\\d+)?D)?(T(-?\\d+([.,]\\d+)?H)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?S)?)?$");
+  private static final Pattern ISO8601_DURATION = Pattern.compile("^-?P(?=.*[YMWDHMS])(-?\\d+([.,]\\d+)?Y)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?W)?(-?\\d+([.,]\\d+)?D)?(T(?=.*[HMS])(-?\\d+([.,]\\d+)?H)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?S)?)?$");
 
+  /**
+   * Checks if the given value is a valid duration.
+   *
+   * @param  value  the value to be checked
+   * @return        true if the value is a valid duration, false otherwise
+   */
   private static boolean testDuration(String value) {
     return value.length() > 1 &&
       value.length() < 80 &&
-      (DURATION_A.matcher(value).find() ||
-        (DURATIION_B.matcher(value).find() &&
-          DURATIION_C.matcher(value).find())) ||
-      DURATION_D.matcher(value).find();
+      ISO8601_DURATION.matcher(value).find();
   }
 
   private static final Pattern FASTDATETIME = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)$", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -182,9 +182,9 @@ public class Format {
     return NOT_URI_FRAGMENT.matcher(value).find() && URI_PATTERN.matcher(value).find();
   }
 
-  private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
-  private static final Pattern DURATIION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
-  private static final Pattern DURATIION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
+  private static final Pattern DURATION_A = Pattern.compile("^-?P\\d+([.,]\\d+)?W$");
+  private static final Pattern DURATIION_B = Pattern.compile("^-?P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
+  private static final Pattern DURATIION_C = Pattern.compile("^-?P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
 
   private static boolean testDuration(String value) {
     return value.length() > 1 &&

--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -182,17 +182,18 @@ public class Format {
     return NOT_URI_FRAGMENT.matcher(value).find() && URI_PATTERN.matcher(value).find();
   }
 
-  private static final Pattern DURATION_A = Pattern.compile("^-?P\\d+([.,]\\d+)?W$");
-  private static final Pattern DURATIION_B = Pattern.compile("^-?P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
-  private static final Pattern DURATIION_C = Pattern.compile("^-?P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
-  // Matches to true if a duration string is not a zero duration with a minus sign in front.
-  private static final Pattern DURATION_D = Pattern.compile("^(-.*[1-9].*|[^-].*)$");
+  private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
+  private static final Pattern DURATIION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
+  private static final Pattern DURATIION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
+  private static final Pattern DURATION_D = Pattern.compile("^-?P(-?\\d+(\\.\\d+)?Y)?(-?\\d+(\\.\\d+)?M)?(-?\\d+(\\.\\d+)?W)?(-?\\d+(\\.\\d+)?D)?(T(-?\\d+(\\.\\d+)?H)?(-?\\d+(\\.\\d+)?M)?(-?\\d+(\\.\\d+)?S)?)?$");
 
   private static boolean testDuration(String value) {
     return value.length() > 1 &&
       value.length() < 80 &&
-      (DURATION_A.matcher(value).find() || (DURATIION_B.matcher(value).find() && DURATIION_C.matcher(value).find())) &&
-      (DURATION_D.matcher(value).find());
+      (DURATION_A.matcher(value).find() ||
+        (DURATIION_B.matcher(value).find() &&
+          DURATIION_C.matcher(value).find())) ||
+      DURATION_D.matcher(value).find();
   }
 
   private static final Pattern FASTDATETIME = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)$", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -185,7 +185,7 @@ public class Format {
   private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
   private static final Pattern DURATIION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
   private static final Pattern DURATIION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
-  private static final Pattern DURATION_D = Pattern.compile("^-?P(-?\\d+(\\.\\d+)?Y)?(-?\\d+(\\.\\d+)?M)?(-?\\d+(\\.\\d+)?W)?(-?\\d+(\\.\\d+)?D)?(T(-?\\d+(\\.\\d+)?H)?(-?\\d+(\\.\\d+)?M)?(-?\\d+(\\.\\d+)?S)?)?$");
+  private static final Pattern DURATION_D = Pattern.compile("^-?P(-?\\d+([.,]\\d+)?Y)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?W)?(-?\\d+([.,]\\d+)?D)?(T(-?\\d+([.,]\\d+)?H)?(-?\\d+([.,]\\d+)?M)?(-?\\d+([.,]\\d+)?S)?)?$");
 
   private static boolean testDuration(String value) {
     return value.length() > 1 &&

--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -185,13 +185,14 @@ public class Format {
   private static final Pattern DURATION_A = Pattern.compile("^-?P\\d+([.,]\\d+)?W$");
   private static final Pattern DURATIION_B = Pattern.compile("^-?P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
   private static final Pattern DURATIION_C = Pattern.compile("^-?P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
+  // Matches to true if a duration string is not a zero duration with a minus sign in front.
+  private static final Pattern DURATION_D = Pattern.compile("^(-.*[1-9].*|[^-].*)$");
 
   private static boolean testDuration(String value) {
     return value.length() > 1 &&
       value.length() < 80 &&
-      (DURATION_A.matcher(value).find() ||
-        (DURATIION_B.matcher(value).find() &&
-          DURATIION_C.matcher(value).find()));
+      (DURATION_A.matcher(value).find() || (DURATIION_B.matcher(value).find() && DURATIION_C.matcher(value).find())) &&
+      (DURATION_D.matcher(value).find());
   }
 
   private static final Pattern FASTDATETIME = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)$", Pattern.CASE_INSENSITIVE);

--- a/src/test/java/io/vertx/json/schema/ValidationTest.java
+++ b/src/test/java/io/vertx/json/schema/ValidationTest.java
@@ -224,4 +224,32 @@ class ValidationTest {
 
     repository.validator("schema-parent.json").validate(json).checkValidity();
   }
+
+  @Test
+  void testNegativeDurationValidation() throws JsonSchemaValidationException {
+
+    SchemaRepository repository = SchemaRepository.create(new JsonSchemaOptions().setDraft(Draft.DRAFT201909).setBaseUri("app://"));
+
+    repository.dereference("negative-duration.json", JsonSchema.of(
+      new JsonObject("{\n" +
+        "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+        "  \"description\": \"A schema with a duration.\",\n" +
+        "  \"type\": \"object\",\n" +
+        "  \"additionalProperties\": false,\n" +
+        "  \"properties\": {\n" +
+        "    \"duration\": {\n" +
+        "      \"description\": \"a duration property\",\n" +
+        "      \"type\": \"string\",\n" +
+        "      \"format\": \"duration\"\n" +
+        "    }\n" +
+        "  }\n" +
+        "}")
+    ));
+
+    JsonObject positiveDuration = new JsonObject().put("duration", "P3W");
+    JsonObject negativeDuration = new JsonObject().put("duration", "-P3W");
+
+    repository.validator("negative-duration.json").validate(positiveDuration).checkValidity();
+    repository.validator("negative-duration.json").validate(negativeDuration).checkValidity();
+  }
 }

--- a/src/test/java/io/vertx/json/schema/ValidationTest.java
+++ b/src/test/java/io/vertx/json/schema/ValidationTest.java
@@ -230,7 +230,7 @@ class ValidationTest {
 
     SchemaRepository repository = SchemaRepository.create(new JsonSchemaOptions().setDraft(Draft.DRAFT201909).setBaseUri("app://"));
 
-    repository.dereference("negative-duration.json", JsonSchema.of(
+    repository.dereference("acceptable-duration.json", JsonSchema.of(
       new JsonObject("{\n" +
         "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
         "  \"description\": \"A schema with a duration.\",\n" +
@@ -248,8 +248,17 @@ class ValidationTest {
 
     JsonObject positiveDuration = new JsonObject().put("duration", "P3W");
     JsonObject negativeDuration = new JsonObject().put("duration", "-P3W");
+    JsonObject positiveNullDuration = new JsonObject().put("duration", "P0W");
+    JsonObject negativeNullDuration = new JsonObject().put("duration", "-PT0S");
 
-    repository.validator("negative-duration.json").validate(positiveDuration).checkValidity();
-    repository.validator("negative-duration.json").validate(negativeDuration).checkValidity();
+    repository.validator("acceptable-duration.json").validate(positiveDuration).checkValidity();
+    repository.validator("acceptable-duration.json").validate(negativeDuration).checkValidity();
+    repository.validator("acceptable-duration.json").validate(positiveNullDuration).checkValidity();
+    try {
+      repository.validator("acceptable-duration.json").validate(negativeNullDuration).checkValidity();
+      fail("Should have thrown an exception");
+    } catch (JsonSchemaValidationException e) {
+      // OK
+    }
   }
 }

--- a/src/test/java/io/vertx/json/schema/ValidationTest.java
+++ b/src/test/java/io/vertx/json/schema/ValidationTest.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import java.util.function.Consumer;
-
 @ExtendWith(VertxExtension.class)
 class ValidationTest {
 
@@ -225,67 +223,5 @@ class ValidationTest {
 
 
     repository.validator("schema-parent.json").validate(json).checkValidity();
-  }
-
-  @Test
-  void testDurationValidation() {
-
-    SchemaRepository repository = SchemaRepository.create(new JsonSchemaOptions().setDraft(Draft.DRAFT201909).setBaseUri("app://"));
-
-    repository.dereference("acceptable-duration.json", JsonSchema.of(
-      new JsonObject("{\n" +
-        "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
-        "  \"description\": \"A schema with a duration.\",\n" +
-        "  \"type\": \"object\",\n" +
-        "  \"additionalProperties\": false,\n" +
-        "  \"properties\": {\n" +
-        "    \"duration\": {\n" +
-        "      \"description\": \"a duration property\",\n" +
-        "      \"type\": \"string\",\n" +
-        "      \"format\": \"duration\"\n" +
-        "    }\n" +
-        "  }\n" +
-        "}")
-    ));
-
-    Consumer<String> shouldValidate = duration -> {
-      try {
-        repository.validator("acceptable-duration.json").validate(new JsonObject().put("duration", duration)).checkValidity();
-      } catch (JsonSchemaValidationException ignored) {
-        fail("Duration " + duration + " should pass validation.");
-      }
-    };
-
-    Consumer<String> shouldNotValidate = duration -> {
-      try {
-        repository.validator("acceptable-duration.json").validate(new JsonObject().put("duration", duration)).checkValidity();
-        fail("Duration " + duration + " should not pass validation.");
-      } catch (JsonSchemaValidationException ignored) {}
-    };
-
-    shouldValidate.accept("PT0S");
-    shouldValidate.accept("-PT0S");
-    shouldValidate.accept("PT-0S");
-    shouldValidate.accept("P1Y");
-    shouldValidate.accept("P1M");
-    shouldValidate.accept("P1W");
-    shouldValidate.accept("P1D");
-    shouldValidate.accept("PT1H");
-    shouldValidate.accept("PT1M");
-    shouldValidate.accept("PT1S");
-    shouldValidate.accept("P1Y2M");
-    shouldValidate.accept("P1M2W");
-    shouldValidate.accept("P1W2D");
-    shouldNotValidate.accept("P1M2Y");
-    shouldNotValidate.accept("P1W2M");
-    shouldNotValidate.accept("P1D2W");
-    shouldValidate.accept("PT1H2M");
-    shouldValidate.accept("PT1M2S");
-    shouldNotValidate.accept("PT1M2H");
-    shouldNotValidate.accept("PT1S2M");
-    shouldValidate.accept("P1Y2M3W4DT5H6M7S");
-    shouldValidate.accept("P-1Y-2M-3W-4DT-5H-6M-7S");
-    shouldValidate.accept("-P-1.0Y2.2M-33.4W-4.2DT5H-7S");
-    shouldValidate.accept("-P-1,0Y2,2M-33,4W-4,2DT5H-7S");
   }
 }

--- a/src/test/java/io/vertx/json/schema/ValidationTest.java
+++ b/src/test/java/io/vertx/json/schema/ValidationTest.java
@@ -286,5 +286,6 @@ class ValidationTest {
     shouldValidate.accept("P1Y2M3W4DT5H6M7S");
     shouldValidate.accept("P-1Y-2M-3W-4DT-5H-6M-7S");
     shouldValidate.accept("-P-1.0Y2.2M-33.4W-4.2DT5H-7S");
+    shouldValidate.accept("-P-1,0Y2,2M-33,4W-4,2DT5H-7S");
   }
 }

--- a/src/test/resources/test-suite-tck.json
+++ b/src/test/resources/test-suite-tck.json
@@ -7039,6 +7039,16 @@
               "valid": true
             },
             {
+              "description": "negative zero time, in seconds",
+              "data": "-PT0S",
+              "valid": true
+            },
+            {
+              "description": "negative seconds zero time component",
+              "data": "PT-0S",
+              "valid": true
+            },
+            {
               "description": "zero time, in days",
               "data": "P0D",
               "valid": true
@@ -7069,9 +7079,29 @@
               "valid": true
             },
             {
-              "description": "weeks cannot be combined with other units",
+              "description": "weeks can be combined with other units",
               "data": "P1Y2W",
-              "valid": false
+              "valid": true
+            },
+            {
+              "description": "negative duration",
+              "data": "-P1Y2W",
+              "valid": true
+            },
+            {
+              "description": "time scale components with fractions using commas",
+              "data": "P1,0Y2,2M33,4W4,4DT5,5H7,7S",
+              "valid": true
+            },
+            {
+              "description": "time scale components with fractions using commas",
+              "data": "P1.0Y2.2M33.4W4.4DT5.5H7.7S",
+              "valid": true
+            },
+            {
+              "description": "differing sign of time scale components",
+              "data": "P-1WT1S",
+              "valid": true
             }
           ]
         }
@@ -21659,9 +21689,9 @@
               "valid": true
             },
             {
-              "description": "weeks cannot be combined with other units",
+              "description": "weeks can be combined with other units",
               "data": "P1Y2W",
-              "valid": false
+              "valid": true
             }
           ]
         }


### PR DESCRIPTION
A fix to pass validation of negative ISO8601 duration string. As this is allowed in ISO8601 as of 2019.

Related PRs:
 * https://github.com/eclipse-vertx/vertx-json-schema/pull/117
 * https://github.com/ajv-validator/ajv-formats/pull/87