### PR TITLE
Adding support for contentEncoding for draft7.

### DIFF
--- a/src/main/java/io/vertx/json/schema/Draft.java
+++ b/src/main/java/io/vertx/json/schema/Draft.java
@@ -27,33 +27,35 @@ public enum Draft {
    *
    * Usually used by OpenAPI 3.0
    */
-  DRAFT4("http://json-schema.org/draft-04/schema#"),
+  DRAFT4("http://json-schema.org/draft-04/schema#", 0),
 
   /**
    * Draft 7 - <a href="http://json-schema.org/draft-07/schema#">http://json-schema.org/draft-07/schema#</a>
    *
    * Commonly used by many projects
    */
-  DRAFT7("http://json-schema.org/draft-07/schema#"),
+  DRAFT7("http://json-schema.org/draft-07/schema#", 1),
 
   /**
    * Draft 2019-09 - <a href="https://json-schema.org/draft/2019-09/schema">https://json-schema.org/draft/2019-09/schema</a>
    *
    * Commonly used by many projects
    */
-  DRAFT201909("https://json-schema.org/draft/2019-09/schema"),
+  DRAFT201909("https://json-schema.org/draft/2019-09/schema", 2),
 
   /**
    * Draft 2020-12 - <a href="https://json-schema.org/draft/2020-12/schema">https://json-schema.org/draft/2020-12/schema</a>
    *
    * Usually used by OpenAPI 3.1
    */
-  DRAFT202012("https://json-schema.org/draft/2020-12/schema");
+  DRAFT202012("https://json-schema.org/draft/2020-12/schema", 3);
 
   private final String identifier;
+  private final int order;
 
-  Draft(String identifier) {
+  Draft(String identifier, int order) {
     this.identifier = identifier;
+    this.order = order;
   }
 
   /**
@@ -108,4 +110,21 @@ public enum Draft {
       throw new IllegalArgumentException("Unsupported draft identifier: " + string);
     }
   }
+
+  /**
+   * @param draft to check against
+   * @return true if the draft instance was released after the draft provided.
+   */
+  public boolean isAfter(Draft draft) {
+    return draft.order < this.order;
+  }
+
+  /**
+   * @param draft to check against
+   * @return true if the draft instance was released before the draft provided.
+   */
+  public boolean isBefore(Draft draft) {
+    return draft.order > this.order;
+  }
+
 }

--- a/src/main/java/io/vertx/json/schema/impl/Format.java
+++ b/src/main/java/io/vertx/json/schema/impl/Format.java
@@ -9,10 +9,70 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Format {
 
+  private static final Pattern BASE16 = Pattern.compile("[0-9a-f]", CASE_INSENSITIVE);
+  private static final Pattern BASE32 = Pattern.compile("^(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}={6}|[A-Z2-7]{4}={4}|[A-Z2-7]{5}={3}|[A-Z2-7]{7}=)?$");
+  private static final Pattern BASE64 = Pattern.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A" +
+    "-Za-z0-9+/]{2}==)$");
+  private static final Pattern RELATIVE_JSON_POINTER = Pattern.compile("^(?:0|[1-9][0-9]*)(?:#|(?:\\/(?:[^~/]|~0|~1)" +
+    "*)*)$");
+  private static final Pattern JSON_POINTER_URI_FRAGMENT = Pattern.compile("^#(?:\\/(?:[a-z0-9_\\-.!$&'()*+,;" +
+    ":=@]|%[0-9a-f]{2}|~0|~1)*)*$", CASE_INSENSITIVE);
+  private static final Pattern JSON_POINTER = Pattern.compile("^(?:\\/(?:[^~/]|~0|~1)*)*$");
+  private static final Pattern UUID = Pattern.compile("^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$", CASE_INSENSITIVE);
+  private static final Pattern Z_ANCHOR = Pattern.compile("[^\\\\]\\\\Z");
+  // optimized http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
+  private static final Pattern IPV6 = Pattern.compile("^((([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9a-f]{1,4}:){5}(((:[0-9a-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9a-f]{1,4}:){4}(((:[0-9a-f]{1,4}){1,3})|((:[0-9a-f]{1,4})?:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:)))$", CASE_INSENSITIVE);
+
+  // optimized https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
+  private static final Pattern IPV4 = Pattern.compile("^(?:(?:25[0-5]|2[0-4]\\d|[1]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)$");
+  private static final Pattern HOSTNAME = Pattern.compile("^(?=.{1,253}\\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\\.?$", CASE_INSENSITIVE);
+
+  // https://github.com/ExodusMovement/schemasafe/blob/master/src/formats.js
+  private static final Pattern EMAIL_HOST = Pattern.compile("^[a-z0-9.-]+$", CASE_INSENSITIVE);
+  private static final Pattern EMAIL_NAME = Pattern.compile("^[a-z0-9.!#$%&'*+/=?^_`\\{|\\}~-]+$", CASE_INSENSITIVE);
+  private static final Pattern EMAIL_HOST_PART = Pattern.compile("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$", CASE_INSENSITIVE);
+  // For the source: https://gist.github.com/dperini/729294
+  // For test cases: https://mathiasbynens.be/demo/url-regex
+  private static final Pattern URL_ = Pattern.compile("^(?:(?:https?|ftp):\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!10(?:\\.\\d{1,3}){3})(?!127(?:\\.\\d{1,3}){3})(?!169\\.254(?:\\.\\d{1,3}){2})(?!192\\.168(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?(?:\\/[^\\s]*)?$", CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+  //IDN emails can have - and . throughout unlike a normal email address. The email host part can also have the same.
+  private static final Pattern IDN_EMAIL_PUNY = Pattern.compile("^xn--[a-z0-9-.]*@[a-z0-9-.]*$");
+  private static final Pattern IDN_EMAIL_HOST = Pattern.compile("^[a-z0-9-.]*");
+  private static final Pattern IDN_EMAIL_NAME = Pattern.compile("^xn--[a-z0-9-.]*$");
+  private static final Pattern IDN_EMAIL_HOST_PART = Pattern.compile("^[a-z0-9-]([a-z0-9-]{0,61}[a-z0-9-])?$");
+  private static final Pattern NOT_URI_FRAGMENT = Pattern.compile("\\/|:");
+  private static final Pattern URI_PATTERN = Pattern.compile("^(?:[a-z][a-z0-9+\\-.]*:)(?:\\/?\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\\.[a-z0-9\\-._~!$&'()*+,;=:]+)\\]|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)|(?:[a-z0-9\\-._~!$&'()*+,;=]|%[0-9a-f]{2})*)(?::\\d*)?(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*|\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)(?:\\?(?:[a-z0-9\\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?$", CASE_INSENSITIVE);
+  private static final Pattern URIREF = Pattern.compile("^(?:[a-z][a-z0-9+\\-.]*:)?(?:\\/?\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\\.[a-z0-9\\-._~!$&'()*+,;=:]+)\\]|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)|(?:[a-z0-9\\-._~!$&'\"()*+,;=]|%[0-9a-f]{2})*)(?::\\d*)?(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*|\\/(?:(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\\?(?:[a-z0-9\\-._~!$&'\"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\\-._~!$&'\"()*+,;=:@/?]|%[0-9a-f]{2})*)?$", CASE_INSENSITIVE);
+  // uri-template: https://tools.ietf.org/html/rfc6570
+  private static final Pattern URITEMPLATE = Pattern.compile("^(?:(?:[^\\x00-\\x20\"'<>%\\\\^`\\{|\\}]|%[0-9a-f]{2})|\\{[+#./;?&=,!@|]?(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\\*)?(?:,(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\\*)?)*\\})*$", CASE_INSENSITIVE);
+  private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
+  private static final Pattern DURATION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
+  private static final Pattern DURATION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
+  private static final Pattern FASTDATETIME = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z?|[+-]\\d\\d(?::?\\d\\d)?)$", CASE_INSENSITIVE);
+  //IDN Puny code is only ever in this format. xn--abc.xyz
+  private static final Pattern IDN_HOSTNAME_PUNY = Pattern.compile("^xn--[a-z0-9-.]*$");
+
+  // This is checking various other combinations of invalid characters/combinations of invalid characters.
+  private static final Pattern IDN_HOSTNAME_UNICODE = Pattern
+    .compile("^.*\\u302e.*|(^.*?[^l]\\u00b7.|.*l\\u00b7[^l]|\\u00b7$|^\\u00b7.)|(.*\\u30fB[^\\u3041\\u30A1\\u4e08].*|^\\u30fB$)|(^[\\u05f3\\u05f4].*)$"
+      , Pattern.UNICODE_CHARACTER_CLASS);
+
+  // This is checking the start of the word for Mc,Me or Mn characters.
+  // Mc -> Spacing_Combining_Mark
+  // Me -> Enclosing_Mark
+  // Mn -> Non_Spacing_Mark (excluding if Virma \\u094d follows
+  private static final Pattern IDN_HOSTNAME_STARTING_ERRORS = Pattern
+    .compile("^\\p{gc=Mc}|^\\p{gc=Me}|^\\p{gc=Mn}(?!\\u094d)", Pattern.UNICODE_CHARACTER_CLASS);
+  // date-time: http://tools.ietf.org/html/rfc3339#section-5.6
+  private static final Pattern FASTTIME = Pattern.compile("^(?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)?$", CASE_INSENSITIVE);
+  private static final Pattern VALID_LEAP_SECONDS = Pattern.compile("^23:59:60(?:\\.\\d+)?(?:z|[+-]00(?::?00)?)?$", CASE_INSENSITIVE);
+
+  // date: http://tools.ietf.org/html/rfc3339#section-5.6
+  private static final Pattern FASTDATE = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d$");
+
   public static boolean fastFormat(String format, String value) {
     switch (format) {
       case "byte":
-        return testByte(value);
+        return checkPattern(value, BASE64);
       case "date":
         return testDate(value);
       case "time":
@@ -22,31 +82,32 @@ public class Format {
       case "duration":
         return testDuration(value);
       case "uri":
-        return testUri(value);
+        // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html + optional protocol + required "."
+        return checkPattern(value, NOT_URI_FRAGMENT) && checkPattern(value, URI_PATTERN);
       case "uri-reference":
-        return testUriReference(value);
+        return checkPattern(value, URIREF);
       case "uri-template":
-        return testUriTemplate(value);
+        return checkPattern(value, URITEMPLATE);
       case "url":
-        return testUrl(value);
+        return checkPattern(value,URL_);
       case "email":
         return testEmail(value);
       case "hostname":
-        return testHostname(value);
+        return checkPattern(value, HOSTNAME);
       case "ipv4":
-        return testIpv4(value);
+        return checkPattern(value, IPV4);
       case "ipv6":
-        return testIpv6(value);
+        return checkPattern(value, IPV6);
       case "regex":
         return testRegex(value);
       case "uuid":
-        return testUuid(value);
+        return checkPattern(value, UUID);
       case "json-pointer":
-        return testJsonPointer(value);
+        return checkPattern(value, JSON_POINTER);
       case "json-pointer-uri-fragment":
-        return testJsonPointerUriFragment(value);
+        return checkPattern(value, JSON_POINTER_URI_FRAGMENT);
       case "relative-json-pointer":
-        return testRelativeJsonPointer(value);
+        return checkPattern(value, RELATIVE_JSON_POINTER);
       case "idn-hostname":
         return testIdnHostname(value);
       case "idn-email":
@@ -57,43 +118,25 @@ public class Format {
     }
   }
 
-  private static final Pattern BASE64 = Pattern.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A" +
-    "-Za-z0-9+/]{2}==)$");
-
-  private static boolean testByte(String value) {
-    return BASE64.matcher(value).find();
+  public static boolean testContentEncoding(String format, String value) {
+    switch(format) {
+      case "base64":
+        return checkPattern(value, BASE64);
+      case "base32":
+        return checkPattern(value, BASE32);
+      case "base16":
+        return checkPattern(value, BASE16);
+      default:
+        return true;
+    }
   }
 
-  private static final Pattern RELATIVE_JSON_POINTER = Pattern.compile("^(?:0|[1-9][0-9]*)(?:#|(?:\\/(?:[^~/]|~0|~1)" +
-    "*)*)$");
-
-  private static boolean testRelativeJsonPointer(String value) {
-    return RELATIVE_JSON_POINTER.matcher(value).find();
+  private static boolean checkPattern(String value, Pattern p) {
+    return p.matcher(value).find();
   }
-
-  private static final Pattern JSON_POINTER_URI_FRAGMENT = Pattern.compile("^#(?:\\/(?:[a-z0-9_\\-.!$&'()*+,;" +
-    ":=@]|%[0-9a-f]{2}|~0|~1)*)*$", CASE_INSENSITIVE);
-
-  private static boolean testJsonPointerUriFragment(String value) {
-    return JSON_POINTER_URI_FRAGMENT.matcher(value).find();
-  }
-
-  private static final Pattern JSON_POINTER = Pattern.compile("^(?:\\/(?:[^~/]|~0|~1)*)*$");
-
-  private static boolean testJsonPointer(String value) {
-    return JSON_POINTER.matcher(value).find();
-  }
-
-  private static final Pattern UUID = Pattern.compile("^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$", CASE_INSENSITIVE);
-
-  private static boolean testUuid(String value) {
-    return UUID.matcher(value).find();
-  }
-
-  private static final Pattern Z_ANCHOR = Pattern.compile("[^\\\\]\\\\Z");
 
   private static boolean testRegex(String value) {
-    if (Z_ANCHOR.matcher(value).find()) {
+    if (checkPattern(value, Z_ANCHOR)) {
       return false;
     }
     try {
@@ -104,31 +147,6 @@ public class Format {
     }
   }
 
-  // optimized http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
-  private static final Pattern IPV6 = Pattern.compile("^((([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9a-f]{1,4}:){5}(((:[0-9a-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9a-f]{1,4}:){4}(((:[0-9a-f]{1,4}){1,3})|((:[0-9a-f]{1,4})?:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:)))$", CASE_INSENSITIVE);
-
-  private static boolean testIpv6(String value) {
-    return IPV6.matcher(value).find();
-  }
-
-  // optimized https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
-  private static final Pattern IPV4 = Pattern.compile("^(?:(?:25[0-5]|2[0-4]\\d|[1]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)$");
-
-  private static boolean testIpv4(String value) {
-    return IPV4.matcher(value).find();
-  }
-
-  private static final Pattern HOSTNAME = Pattern.compile("^(?=.{1,253}\\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\\.?$", CASE_INSENSITIVE);
-
-  private static boolean testHostname(String value) {
-    return HOSTNAME.matcher(value).find();
-  }
-
-  private static final Pattern EMAIL_HOST = Pattern.compile("^[a-z0-9.-]+$", CASE_INSENSITIVE);
-  private static final Pattern EMAIL_NAME = Pattern.compile("^[a-z0-9.!#$%&'*+/=?^_`\\{|\\}~-]+$", CASE_INSENSITIVE);
-  private static final Pattern EMAIL_HOST_PART = Pattern.compile("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$", CASE_INSENSITIVE);
-
-  // https://github.com/ExodusMovement/schemasafe/blob/master/src/formats.js
   private static boolean testEmail(String value) {
     return testEmail(value, EMAIL_HOST, EMAIL_NAME, EMAIL_HOST_PART);
   }
@@ -151,91 +169,50 @@ public class Format {
       return false;
     }
     if (
-      !emailHostMatcher.matcher(parts[1]).find() ||
-        !emailNameMatcher.matcher(parts[0]).find()
+      !checkPattern( parts[1], emailHostMatcher)||
+        !checkPattern(parts[0], emailNameMatcher)
     ) {
       return false;
     }
     for (String part : parts[1].split("\\.")) {
-      if (!emailHostPartMatcher.matcher(part).find()) {
+      if (!checkPattern(part, emailHostPartMatcher)) {
         return false;
       }
     }
     return true;
   }
 
-  // For the source: https://gist.github.com/dperini/729294
-  // For test cases: https://mathiasbynens.be/demo/url-regex
-  private static final Pattern URL_ = Pattern.compile("^(?:(?:https?|ftp):\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!10(?:\\.\\d{1,3}){3})(?!127(?:\\.\\d{1,3}){3})(?!169\\.254(?:\\.\\d{1,3}){2})(?!192\\.168(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?(?:\\/[^\\s]*)?$", CASE_INSENSITIVE | Pattern.UNICODE_CASE);
-
-  private static boolean testUrl(String value) {
-    return URL_.matcher(value).find();
-  }
-
-  // uri-template: https://tools.ietf.org/html/rfc6570
-  private static final Pattern URITEMPLATE = Pattern.compile("^(?:(?:[^\\x00-\\x20\"'<>%\\\\^`\\{|\\}]|%[0-9a-f]{2})|\\{[+#./;?&=,!@|]?(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\\*)?(?:,(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\\*)?)*\\})*$", CASE_INSENSITIVE);
-
-  private static boolean testUriTemplate(String value) {
-    return URITEMPLATE.matcher(value).find();
-  }
-
-  private static final Pattern URIREF = Pattern.compile("^(?:[a-z][a-z0-9+\\-.]*:)?(?:\\/?\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\\.[a-z0-9\\-._~!$&'()*+,;=:]+)\\]|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)|(?:[a-z0-9\\-._~!$&'\"()*+,;=]|%[0-9a-f]{2})*)(?::\\d*)?(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*|\\/(?:(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'\"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\\?(?:[a-z0-9\\-._~!$&'\"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\\-._~!$&'\"()*+,;=:@/?]|%[0-9a-f]{2})*)?$", CASE_INSENSITIVE);
-
-  private static boolean testUriReference(String value) {
-    return URIREF.matcher(value).find();
-  }
-
-  private static final Pattern NOT_URI_FRAGMENT = Pattern.compile("\\/|:");
-  private static final Pattern URI_PATTERN = Pattern.compile("^(?:[a-z][a-z0-9+\\-.]*:)(?:\\/?\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\\.[a-z0-9\\-._~!$&'()*+,;=:]+)\\]|(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)|(?:[a-z0-9\\-._~!$&'()*+,;=]|%[0-9a-f]{2})*)(?::\\d*)?(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*|\\/(?:(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\\/(?:[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)(?:\\?(?:[a-z0-9\\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?$", CASE_INSENSITIVE);
-
-  private static boolean testUri(String value) {
-    // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html + optional protocol + required "."
-    return NOT_URI_FRAGMENT.matcher(value).find() && URI_PATTERN.matcher(value).find();
-  }
-
-  private static final Pattern DURATION_A = Pattern.compile("^P\\d+([.,]\\d+)?W$");
-  private static final Pattern DURATIION_B = Pattern.compile("^P[\\dYMDTHS]*(\\d[.,]\\d+)?[YMDHS]$");
-  private static final Pattern DURATIION_C = Pattern.compile("^P([.,\\d]+Y)?([.,\\d]+M)?([.,\\d]+D)?(T([.,\\d]+H)?([.,\\d]+M)?([.,\\d]+S)?)?$");
-
   private static boolean testDuration(String value) {
     return value.length() > 1 &&
       value.length() < 80 &&
-      (DURATION_A.matcher(value).find() ||
-        (DURATIION_B.matcher(value).find() &&
-          DURATIION_C.matcher(value).find()));
+      (checkPattern(value, DURATION_A) ||
+        (checkPattern(value, DURATION_B) &&
+          checkPattern(value, DURATION_C)));
   }
 
-  private static final Pattern FASTDATETIME = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z?|[+-]\\d\\d(?::?\\d\\d)?)$", CASE_INSENSITIVE);
-
   private static boolean testDateTime(String value) {
-    if(!FASTDATETIME.matcher(value).find()) {
+    if(!checkPattern(value, FASTDATETIME)) {
       return false;
     }
     return validateISOTime(DateTimeFormatter.ISO_DATE_TIME, value);
   }
 
-  // date-time: http://tools.ietf.org/html/rfc3339#section-5.6
-  private static final Pattern FASTTIME = Pattern.compile("^(?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)?$", CASE_INSENSITIVE);
-  private static final Pattern VALID_LEAP_SECONDS = Pattern.compile("^23:59:60(?:\\.\\d+)?(?:z|[+-]00(?::?00)?)?$", CASE_INSENSITIVE);
   private static boolean testTime(String value) {
-    if(!FASTTIME.matcher(value).find()) {
+    if(!checkPattern(value, FASTTIME)) {
       return false;
     }
 
     //The built-in ISO_TIME does not account for leap seconds.
     // So if it IS a leap second (or matches) just assume that it's OK
-    if(VALID_LEAP_SECONDS.matcher(value).find()) {
+    if(checkPattern(value, VALID_LEAP_SECONDS)) {
       return true;
     }
 
     return validateISOTime(DateTimeFormatter.ISO_TIME, value);
   }
 
-  // date: http://tools.ietf.org/html/rfc3339#section-5.6
-  private static final Pattern FASTDATE = Pattern.compile("^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d$");
-
   private static boolean testDate(String value) {
-    if (!FASTDATE.matcher(value).matches()) {
+    if (!checkPattern(value, FASTDATE)) {
       return false;
     }
 
@@ -251,35 +228,13 @@ public class Format {
     }
   }
 
-  //IDN Puny code is only ever in this format. xn--abc.xyz
-  private static final Pattern IDN_HOSTNAME_PUNY = Pattern.compile("^xn--[a-z0-9-.]*$");
-
-  // This is checking various other combinations of invalid characters/combinations of invalid characters.
-  private static final Pattern IDN_HOSTNAME_UNICODE = Pattern
-    .compile("^.*\\u302e.*|(^.*?[^l]\\u00b7.|.*l\\u00b7[^l]|\\u00b7$|^\\u00b7.)|(.*\\u30fB[^\\u3041\\u30A1\\u4e08].*|^\\u30fB$)|(^[\\u05f3\\u05f4].*)$"
-      , Pattern.UNICODE_CHARACTER_CLASS);
-
-  // This is checking the start of the word for Mc,Me or Mn characters.
-  // Mc -> Spacing_Combining_Mark
-  // Me -> Enclosing_Mark
-  // Mn -> Non_Spacing_Mark (excluding if Virma \\u094d follows
-  private static final Pattern IDN_HOSTNAME_STARTING_ERRORS = Pattern
-    .compile("^\\p{gc=Mc}|^\\p{gc=Me}|^\\p{gc=Mn}(?!\\u094d)", Pattern.UNICODE_CHARACTER_CLASS);
-
-
   private static boolean testIdnHostname(String value) {
     try {
-      return !IDN_HOSTNAME_STARTING_ERRORS.matcher(value).find() && !IDN_HOSTNAME_UNICODE.matcher(value).find() && IDN_HOSTNAME_PUNY.matcher(IDN.toASCII(value)).find();
+      return !checkPattern(value, IDN_HOSTNAME_STARTING_ERRORS) && !checkPattern(value, IDN_HOSTNAME_UNICODE) && checkPattern(IDN.toASCII(value), IDN_HOSTNAME_PUNY);
     } catch(Exception e) {
       return false;
     }
   }
-
-  //IDN emails can have - and . throughout unlike a normal email address. The email host part can also have the same.
-  private static final Pattern IDN_EMAIL_PUNY = Pattern.compile("^xn--[a-z0-9-.]*@[a-z0-9-.]*$");
-  private static final Pattern IDN_EMAIL_HOST = Pattern.compile("^[a-z0-9-.]*");
-  private static final Pattern IDN_EMAIL_NAME = Pattern.compile("^xn--[a-z0-9-.]*$");
-  private static final Pattern IDN_EMAIL_HOST_PART = Pattern.compile("^[a-z0-9-]([a-z0-9-]{0,61}[a-z0-9-])?$");
 
   private static boolean testIdnEmail(String value) {
     try {
@@ -289,7 +244,7 @@ public class Format {
         return testEmail(asciiVersion);
       }
 
-      return IDN_EMAIL_PUNY.matcher(asciiVersion).find() && testEmail(asciiVersion, IDN_EMAIL_HOST, IDN_EMAIL_NAME, IDN_EMAIL_HOST_PART);
+      return checkPattern(asciiVersion, IDN_EMAIL_PUNY) && testEmail(asciiVersion, IDN_EMAIL_HOST, IDN_EMAIL_NAME, IDN_EMAIL_HOST_PART);
     } catch(Exception e) {
       return false;
     }

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -928,12 +928,18 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         if (schema.containsKey("pattern") && !Pattern.compile(schema.get("pattern")).matcher((String) instance).find()) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/pattern"), baseLocation + "/pattern", "String does not match pattern", OutputErrorType.INVALID_VALUE));
         }
-        if (
-          schema.containsKey("format") &&
-            !Format.fastFormat(schema.get("format"), (String) instance)
-        ) {
+        if (schema.containsKey("format") &&
+            !Format.fastFormat(schema.get("format"), (String) instance)) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/format"), baseLocation + "/format", "String does not match format \"" + schema.get("format") + "\"", OutputErrorType.INVALID_VALUE));
         }
+
+        //Content encoding was introduced in Draft7, but was turned into annotated only in draft 2019 and after.
+        if(draft == Draft.DRAFT7 &&
+          schema.containsKey("contentEncoding") &&
+          !Format.testContentEncoding(schema.get("contentEncoding"), (String) instance)) {
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contentEncoding"), baseLocation + "/contentEncoding", "String does not match the content encoding \"" + schema.get("contentEncoding") + "\"", OutputErrorType.INVALID_VALUE));
+        }
+
         break;
       }
     }

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -934,7 +934,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         //Content encoding was introduced in Draft7, but was turned into annotated only in draft 2019 and after.
-        if(draft.isAfter(Draft.DRAFT4) &&
+        if (draft.isAfter(Draft.DRAFT4) &&
           schema.containsKey("contentEncoding") &&
           !Format.testContentEncoding(schema.get("contentEncoding"), (String) instance)) {
           OutputUnit errorUnit = new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contentEncoding"), baseLocation + "/contentEncoding", "String does not match the content encoding \"" + schema.get("contentEncoding") + "\"", OutputErrorType.INVALID_VALUE);

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -934,10 +934,15 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         //Content encoding was introduced in Draft7, but was turned into annotated only in draft 2019 and after.
-        if(draft == Draft.DRAFT7 &&
+        if(draft.isAfter(Draft.DRAFT4) &&
           schema.containsKey("contentEncoding") &&
           !Format.testContentEncoding(schema.get("contentEncoding"), (String) instance)) {
-          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contentEncoding"), baseLocation + "/contentEncoding", "String does not match the content encoding \"" + schema.get("contentEncoding") + "\"", OutputErrorType.INVALID_VALUE));
+          OutputUnit errorUnit = new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contentEncoding"), baseLocation + "/contentEncoding", "String does not match the content encoding \"" + schema.get("contentEncoding") + "\"", OutputErrorType.INVALID_VALUE);
+          if(draft.isAfter(Draft.DRAFT7)) {
+            annotations.add(errorUnit);
+          } else {
+            errors.add(errorUnit);
+          }
         }
 
         break;

--- a/src/test/java/io/vertx/tests/DraftTest.java
+++ b/src/test/java/io/vertx/tests/DraftTest.java
@@ -1,0 +1,33 @@
+package io.vertx.tests;
+
+import io.vertx.json.schema.Draft;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DraftTest {
+
+  public Stream<Arguments> getDraftOrders() {
+    return Stream.of(
+      Arguments.of(Draft.DRAFT4, Draft.DRAFT7, false),
+      Arguments.of(Draft.DRAFT4, Draft.DRAFT201909, false),
+      Arguments.of(Draft.DRAFT4, Draft.DRAFT202012, false),
+      Arguments.of(Draft.DRAFT7, Draft.DRAFT201909, false),
+      Arguments.of(Draft.DRAFT7, Draft.DRAFT202012, false),
+      Arguments.of(Draft.DRAFT201909, Draft.DRAFT202012, false)
+      );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getDraftOrders")
+  public void testDraftOrders(Draft d1, Draft d2, boolean after) {
+    assertThat(d1.isAfter(d2)).isEqualTo(after);
+    assertThat(d1.isBefore(d2)).isEqualTo(!after);
+  }
+
+}

--- a/src/test/java/io/vertx/tests/TCKTest.java
+++ b/src/test/java/io/vertx/tests/TCKTest.java
@@ -173,7 +173,7 @@ public class TCKTest {
         }
       } else {
         if (unsupported) {
-          fail("Test should be marked as supported : " + suiteName + "/" + suiteDescription + "/" + testDescription);
+          fail("Test should be marked as supported : " + (suiteName + "/" + suiteDescription + "/" + testDescription).replace(" ", "\\ "));
 //          UNSUPPORTED.remove(suiteName + "/" + suiteDescription + "/" + testDescription);
         }
       }

--- a/src/test/resources/unsupported-tck-tests.properties
+++ b/src/test/resources/unsupported-tck-tests.properties
@@ -114,9 +114,7 @@ draft4/optional/unicode/unicode\ semantics\ should\ be\ used\ for\ all\ pattern\
 draft4/optional/unicode/unicode\ semantics\ should\ be\ used\ for\ all\ patternProperties\ matching/literal\ unicode\ character\ in\ json\ string=skip
 draft4/optional/unicode/unicode\ semantics\ should\ be\ used\ for\ all\ patternProperties\ matching/unicode\ character\ in\ hex\ format\ in\ string=skip
 draft4/optional/zeroTerminatedFloats/some\ languages\ do\ not\ distinguish\ between\ different\ types\ of\ numeric\ value/a\ float\ is\ not\ an\ integer\ even\ without\ fractional\ part=skip
-draft7/optional/content/validation\ of\ binary-encoded\ media\ type\ documents/an\ invalid\ base64\ string\ that\ is\ valid\ JSON=skip
 draft7/optional/content/validation\ of\ binary-encoded\ media\ type\ documents/a\ validly-encoded\ invalid\ JSON\ document=skip
-draft7/optional/content/validation\ of\ binary\ string-encoding/an\ invalid\ base64\ string\ (%\ is\ not\ a\ valid\ character)=skip
 draft7/optional/content/validation\ of\ string-encoded\ content\ based\ on\ media\ type/an\ invalid\ JSON\ document=skip
 draft7/optional/ecmascript-regex/ECMA\ 262\ regex\ escapes\ control\ codes\ with\ \\c\ and\ lower\ letter/matches=skip
 draft7/optional/ecmascript-regex/ECMA\ 262\ \\S\ matches\ everything\ but\ whitespace/EM\ SPACE\ does\ not\ match\ (Space_Separator)=skip


### PR DESCRIPTION
Motivation:

Adding support for contentEncoding which was added to the validation spec in draft7.
https://github.com/eclipse-vertx/vertx-json-schema/issues/139

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
