### PR TITLE
Typo for StringFormat.URI_TEMPLATE

### DIFF
--- a/src/main/java/io/vertx/json/schema/common/dsl/StringFormat.java
+++ b/src/main/java/io/vertx/json/schema/common/dsl/StringFormat.java
@@ -23,7 +23,7 @@ public enum StringFormat {
   REGEX("regex"),
   JSON_POINTER("json-pointer"),
   RELATIVE_JSON_POINTER("relative-json-pointer"),
-  URI_TEMPLATE("uti-template"),
+  URI_TEMPLATE("uri-template"),
   TIME("time");
 
   private final String name;


### PR DESCRIPTION
There a typo for StringFormat.URI_TEMPLATE named as 'uti-template' check: https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/optional/format/uri-template.json that suggest should be 'uri-template'  not 'uti-template'

Motivation:

Fix bug for StringFormat.URI_TEMPLATE

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
