### PR TITLE
Fix StringIndexOutOfBoundsException when resolving a self $ref '#'

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/JsonRef.java
+++ b/src/main/java/io/vertx/json/schema/impl/JsonRef.java
@@ -320,7 +320,9 @@ public final class JsonRef {
     //  [prefix, path]
     final String[] parts = uri.split("#", 2);
 
-    final boolean hashPresent = parts.length == 2 && parts[1] != null;
+    // an empty fragment ("#" or "id#") is equivalent to no fragment at all: the uri refers
+    // to the schema identified by the prefix, e.g.: the root schema when the prefix is empty
+    final boolean hashPresent = parts.length == 2 && parts[1] != null && !parts[1].isEmpty();
 
     final String prefix = parts[0];
     final String path = hashPresent ? parts[1] : null;

--- a/src/test/java/io/vertx/tests/impl/RefTest.java
+++ b/src/test/java/io/vertx/tests/impl/RefTest.java
@@ -204,6 +204,83 @@ class RefTest {
   }
 
   @Test
+  public void testRefToRoot() {
+    JsonObject schema = new JsonObject()
+      .put("type", "object")
+      .put("properties", new JsonObject()
+        .put("children", new JsonObject()
+          .put("type", "array")
+          .put("items", new JsonObject()
+            .put("$ref", "#"))));
+
+    JsonObject resolved = JsonRef.resolve(schema);
+
+    JsonObject items = resolved
+      .getJsonObject("properties")
+      .getJsonObject("children")
+      .getJsonObject("items");
+    assertEquals("object", items.getString("type"));
+    // the ref points back to the root schema itself
+    assertNotNull(
+      items
+        .getJsonObject("properties")
+        .getJsonObject("children")
+        .getJsonObject("items"));
+  }
+
+  @Test
+  public void testRefToRootWithId() {
+    JsonObject schema = new JsonObject()
+      .put("$id", "http://www.example.com/tree/")
+      .put("type", "object")
+      .put("properties", new JsonObject()
+        .put("children", new JsonObject()
+          .put("type", "array")
+          .put("items", new JsonObject()
+            .put("$ref", "#"))));
+
+    JsonObject resolved = JsonRef.resolve(schema);
+
+    JsonObject items = resolved
+      .getJsonObject("properties")
+      .getJsonObject("children")
+      .getJsonObject("items");
+    assertEquals("object", items.getString("type"));
+    assertNotNull(
+      items
+        .getJsonObject("properties")
+        .getJsonObject("children")
+        .getJsonObject("items"));
+  }
+
+  @Test
+  public void testRefToRootThroughRepository() {
+    SchemaRepository repo =
+      SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT4));
+    JsonObject schema = new JsonObject()
+      .put("type", "object")
+      .put("properties", new JsonObject()
+        .put("children", new JsonObject()
+          .put("type", "array")
+          .put("items", new JsonObject()
+            .put("$ref", "#"))));
+    repo.dereference(JsonSchema.of(schema.copy()));
+
+    JsonObject resolved = repo.resolve(schema);
+
+    JsonObject items = resolved
+      .getJsonObject("properties")
+      .getJsonObject("children")
+      .getJsonObject("items");
+    assertEquals("object", items.getString("type"));
+    assertNotNull(
+      items
+        .getJsonObject("properties")
+        .getJsonObject("children")
+        .getJsonObject("items"));
+  }
+
+  @Test
   void testSerialization() {
     SchemaRepository repo =
       SchemaRepository.create(new JsonSchemaOptions().setBaseUri("http://vertx.io").setDraft(Draft.DRAFT202012));


### PR DESCRIPTION
Fixes #141

### Motivation

A schema containing a self-reference `$ref: '#'` (e.g. a recursive tree structure) throws `StringIndexOutOfBoundsException` during resolution:

```
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at io.vertx.json.schema.impl.JsonRef.resolveUri(JsonRef.java:328)
```

In `JsonRef.resolve`, a `$ref` of `#` becomes `id + "#"` (just `#` when there is no `$id`). `resolveUri` then splits it into `["", ""]`, so `hashPresent` was `true` while `path` was empty, and `path.charAt(0)` threw.

### Changes

Treat an empty fragment (`#` or `id#`) the same as no fragment at all, so the reference resolves to the schema identified by the prefix — the root schema for a bare `#`. This is "Option 1" from the issue: it removes the invalid empty-path state entirely instead of guarding the `charAt` call, and an empty fragment never carries pointer segments to `reduce()` anyway.

Added tests covering the reproducer from the issue: direct `JsonRef.resolve`, through `SchemaRepository.resolve` (the path in the reported stack trace), and with a `$id` present.

Note: the follow-up comment in #141 about `$ref: '#/'` failing later in `SchemaValidatorImpl` is a separate lookup-normalization issue and is not addressed here; with `#` fixed that workaround is no longer needed.
