### PR TITLE
Fix ClassCastException when numeric keywords are not Integer

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -443,11 +443,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
 
         final Set<String> keys = ((JsonObject) instance).fieldNames();
 
-        if (schema.containsKey("minProperties") && keys.size() < schema.<Integer>get("minProperties")) {
+        if (schema.containsKey("minProperties") && Numbers.lt(keys.size(), schema.get("minProperties"))) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minProperties"), baseLocation + "/minProperties", "Instance does not have at least " + schema.get("minProperties") + " properties", OutputErrorType.MISSING_VALUE));
         }
 
-        if (schema.containsKey("maxProperties") && keys.size() > schema.<Integer>get("maxProperties")) {
+        if (schema.containsKey("maxProperties") && Numbers.gt(keys.size(), schema.get("maxProperties"))) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxProperties"), baseLocation + "/maxProperties", "Instance does not have at least " + schema.get("maxProperties") + " properties", OutputErrorType.INVALID_VALUE));
         }
 
@@ -666,11 +666,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         break;
       }
       case "array": {
-        if (schema.containsKey("maxItems") && ((JsonArray) instance).size() > schema.<Integer>get("maxItems")) {
+        if (schema.containsKey("maxItems") && Numbers.gt(((JsonArray) instance).size(), schema.get("maxItems"))) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxItems"), baseLocation + "/maxItems", "Array has too many items ( + " + ((JsonArray) instance).size() + " > " + schema.get("maxItems") + ")", OutputErrorType.INVALID_VALUE));
         }
 
-        if (schema.containsKey("minItems") && ((JsonArray) instance).size() < schema.<Integer>get("minItems")) {
+        if (schema.containsKey("minItems") && Numbers.lt(((JsonArray) instance).size(), schema.get("minItems"))) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minItems"), baseLocation + "/minItems", "Array has too few items ( + " + ((JsonArray) instance).size() + " < " + schema.get("minItems") + ")", OutputErrorType.MISSING_VALUE));
         }
 
@@ -785,7 +785,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         if (schema.containsKey("contains")) {
           if (length == 0 && !schema.containsKey("minContains")) {
             errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contains"), baseLocation + "/contains", "Array is empty. It must contain at least one item matching the schema", OutputErrorType.MISSING_VALUE));
-          } else if (schema.containsKey("minContains") && length < schema.<Integer>get("minContains")) {
+          } else if (schema.containsKey("minContains") && Numbers.lt(length, schema.get("minContains"))) {
             errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array has less items (" + length + ") than minContains (" + schema.get("minContains") + ")", OutputErrorType.MISSING_VALUE));
           } else {
             final int errorsLength = errors.size();
@@ -811,7 +811,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               }
             }
 
-            if (contained >= schema.<Integer>get("minContains", 0)) {
+            if (Numbers.gte(contained, schema.get("minContains", 0))) {
               errors = errors.subList(0, Math.min(errors.size(), errorsLength));
             }
 
@@ -821,9 +821,9 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 contained == 0
             ) {
               errors.add(errorsLength, new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/contains"), baseLocation + "/contains", "Array does not contain item matching schema", OutputErrorType.INVALID_VALUE));
-            } else if (schema.containsKey("minContains") && contained < schema.<Integer>get("minContains")) {
+            } else if (schema.containsKey("minContains") && Numbers.lt(contained, schema.get("minContains"))) {
               errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array must contain at least " + schema.get("minContains") + " items matching schema. Only " + contained + " items were found", OutputErrorType.MISSING_VALUE));
-            } else if (schema.containsKey("maxContains") && contained > schema.<Integer>get("maxContains")) {
+            } else if (schema.containsKey("maxContains") && Numbers.gt(contained, schema.get("maxContains"))) {
               errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxContains"), baseLocation + "/maxContains", "Array may contain at most " + schema.get("minContains") + " items matching schema. " + contained + " items were found", OutputErrorType.INVALID_VALUE));
             }
           }

--- a/src/test/java/io/vertx/tests/ValidatorTest.java
+++ b/src/test/java/io/vertx/tests/ValidatorTest.java
@@ -33,6 +33,46 @@ public class ValidatorTest {
 
   @Test
   @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testNumericKeywordsAsLongs() {
+    final JsonObject schema = new JsonObject()
+      .put("type", "object")
+      .put("minProperties", 1L)
+      .put("maxProperties", 2L)
+      .put("properties", new JsonObject()
+        .put("tags", new JsonObject()
+          .put("type", "array")
+          .put("minItems", 1L)
+          .put("maxItems", 3L)
+          .put("contains", new JsonObject().put("type", "string"))
+          .put("minContains", 1L)
+          .put("maxContains", 2L)));
+
+    final Validator validator = Validator.create(
+      JsonSchema.of(schema),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012));
+
+    assertThat(validator.validate(new JsonObject().put("tags", new JsonArray().add("a"))).getValid())
+      .isEqualTo(true);
+
+    // violations are still detected when the keyword value is a Long
+    // minProperties
+    assertThat(validator.validate(new JsonObject()).getValid())
+      .isEqualTo(false);
+    // minItems
+    assertThat(validator.validate(new JsonObject().put("tags", new JsonArray())).getValid())
+      .isEqualTo(false);
+    // maxItems
+    assertThat(validator.validate(new JsonObject().put("tags", new JsonArray().add("a").add("b").add("c").add("d"))).getValid())
+      .isEqualTo(false);
+    // maxContains
+    assertThat(validator.validate(new JsonObject().put("tags", new JsonArray().add("a").add("b").add("c"))).getValid())
+      .isEqualTo(false);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
   public void testAddsSchema() {
     final SchemaRepository repository = SchemaRepository
       .create(


### PR DESCRIPTION
Fixes #147

### Motivation

Validating against a schema whose numeric keywords are held as `Long` fails with:

```
java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer
	at io.vertx.json.schema.impl.SchemaValidatorImpl.validate(SchemaValidatorImpl.java:446)
```

`minProperties`, `maxProperties`, `minItems`, `maxItems`, `minContains` and `maxContains` are read with an unchecked `schema.<Integer>get(...)` cast. A JSON number is not guaranteed to deserialize to `Integer` — e.g. Jackson configured with `USE_LONG_FOR_INTS` produces `Long`, which is how this surfaces through vertx-openapi contract validation. The workaround in the issue (reconfiguring the global `DatabindCodec` mapper) shouldn't be necessary.

### Changes

Compare these keywords through the type-agnostic `Numbers.lt/gt/gte` helpers instead, as the validator already does for `minLength`, `maxLength`, `minimum`, `maximum` and the other numeric keywords. This also makes the comparisons correct for `BigInteger`/`BigDecimal` values, which the helpers handle.

Added a regression test exercising all six keywords with `Long` values, asserting both the passing case and that bound violations are still detected.
