### PR TITLE
Validate multipleOf with exact decimal arithmetic

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -905,11 +905,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
           }
         }
         if (schema.containsKey("multipleOf")) {
-          final double remainder = Numbers.remainder((Number) instance, schema.get("multipleOf"));
-          if (
-            Math.abs(0 - remainder) >= 1.1920929e-7 &&
-              Math.abs(schema.<Number>get("multipleOf").doubleValue() - remainder) >= 1.1920929e-7
-          ) {
+          if (!Numbers.isMultipleOf((Number) instance, schema.get("multipleOf"))) {
             errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/multipleOf"), baseLocation + "/multipleOf", instance + " is not a multiple of " + schema.get("multipleOf"), OutputErrorType.INVALID_VALUE));
           }
         }

--- a/src/main/java/io/vertx/json/schema/impl/Utils.java
+++ b/src/main/java/io/vertx/json/schema/impl/Utils.java
@@ -109,17 +109,24 @@ public class Utils {
       return false;
     }
 
-    public static double remainder(Number instance, Number value) {
-      // for big numbers, go slow
-      if (instance instanceof BigDecimal || value instanceof BigDecimal || instance instanceof BigInteger || value instanceof BigInteger) {
-        return toBigDecimal(instance).remainder(toBigDecimal(value)).doubleValue();
+    public static boolean isMultipleOf(Number instance, Number value) {
+      // non finite values and a zero divisor cannot be checked meaningfully, raise no error
+      if (!isFinite(instance) || !isFinite(value)) {
+        return true;
       }
-      // for floating point use double
-      if (instance instanceof Double || value instanceof Double || instance instanceof Float || value instanceof Float) {
-        return instance.doubleValue() % value.doubleValue();
+      final BigDecimal divisor = toBigDecimal(value);
+      if (divisor.signum() == 0) {
+        return true;
       }
-      // for integer use long
-      return instance.longValue() % value.doubleValue();
+      // compare on the decimal representation to avoid binary floating point rounding artifacts
+      return toBigDecimal(instance).remainder(divisor).signum() == 0;
+    }
+
+    private static boolean isFinite(Number in) {
+      if (in instanceof Double || in instanceof Float) {
+        return Double.isFinite(in.doubleValue());
+      }
+      return true;
     }
 
     public static boolean equals(Number a, Number b) {

--- a/src/test/java/io/vertx/tests/ValidatorTest.java
+++ b/src/test/java/io/vertx/tests/ValidatorTest.java
@@ -73,6 +73,44 @@ public class ValidatorTest {
 
   @Test
   @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testMultipleOfSmallNumbers() {
+    final Validator thousandths = Validator.create(
+      JsonSchema.of(new JsonObject().put("type", "number").put("multipleOf", 0.001)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012));
+
+    for (double valid : new double[]{0.001, 0.002, 1.001, 1.01, 1.02, 123.456, 123456.789}) {
+      assertThat(thousandths.validate(valid).getValid())
+        .as("%s is a multiple of 0.001", valid)
+        .isEqualTo(true);
+    }
+    for (double invalid : new double[]{1.0015, 0.0005}) {
+      assertThat(thousandths.validate(invalid).getValid())
+        .as("%s is not a multiple of 0.001", invalid)
+        .isEqualTo(false);
+    }
+
+    // multiples smaller than a float ulp must still be enforced
+    final Validator tenMillionths = Validator.create(
+      JsonSchema.of(new JsonObject().put("type", "number").put("multipleOf", 0.0000001)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012));
+
+    assertThat(tenMillionths.validate(0.0000002).getValid())
+      .as("0.0000002 is a multiple of 0.0000001")
+      .isEqualTo(true);
+    assertThat(tenMillionths.validate(0.00000015).getValid())
+      .as("0.00000015 is not a multiple of 0.0000001")
+      .isEqualTo(false);
+    assertThat(tenMillionths.validate(0.00000012345).getValid())
+      .as("0.00000012345 is not a multiple of 0.0000001")
+      .isEqualTo(false);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
   public void testAddsSchema() {
     final SchemaRepository repository = SchemaRepository
       .create(


### PR DESCRIPTION
Fixes #106

### Motivation

#106 reported `multipleOf: 0.001` rejecting values like `1.001`, `1.01`, `1.02` in the legacy 4.x `MultipleOfValidatorFactory`. Those cases already pass in the current validator thanks to its epsilon workaround — but the workaround has the opposite defect: the epsilon is absolute (`1.1920929e-7`, FLT_EPSILON), so any `multipleOf` smaller than the epsilon accepts *every* value. For example `0.00000015` validates against `multipleOf: 0.0000001` even though it is 1.5× the divisor — a false accept that matters for schemas describing high-precision quantities (8-decimal currency amounts, coordinates).

### Changes

Replace the epsilon comparison with an exact remainder computed via `BigDecimal` on the decimal representation (`BigDecimal.valueOf`, which the existing `toBigDecimal` helper already uses). This makes the check exact for the decimal values users write in schemas and instances:

- the #106 cases (`1.001` / `0.001` etc.) remain valid — binary rounding artifacts no longer need an epsilon;
- non-multiples below the old epsilon are now correctly rejected;
- non-finite values and a zero divisor keep the previous lenient behavior (no error) instead of throwing.

`Numbers.remainder` had no other callers and is replaced by `Numbers.isMultipleOf`. The official test-suite `multipleOf` cases (small numbers, `1e308` overflow with `multipleOf: 0.5`, float-division-inf) all pass unchanged; full suite green.

Added regression tests covering the #106 values and the sub-epsilon false-accept cases.
