### PR TITLE
Report contains sub-errors at the failing item's location

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -795,7 +795,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
                 ((JsonArray) instance).getValue(j),
                 Schemas.wrap((JsonObject) schema, "contains"),
                 recursiveAnchor,
-                instanceLocation + "/" + i,
+                instanceLocation + "/" + j,
                 schemaLocation + "/contains",
                 baseLocation + "/contains",
                 new HashSet<>(),

--- a/src/test/java/io/vertx/tests/ValidatorTest.java
+++ b/src/test/java/io/vertx/tests/ValidatorTest.java
@@ -73,6 +73,28 @@ public class ValidatorTest {
 
   @Test
   @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testContainsErrorsReportItemLocation() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject()
+        .put("type", "array")
+        .put("contains", new JsonObject().put("type", "string"))
+        .put("minContains", 1)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012)
+        .setOutputFormat(Basic));
+
+    final OutputUnit res = validator.validate(new JsonArray().add(1).add(2));
+
+    assertThat(res.getValid()).isFalse();
+    // each failing item is reported at its own location
+    assertThat(res.getErrors())
+      .anyMatch(e -> "#/0".equals(e.getInstanceLocation()))
+      .anyMatch(e -> "#/1".equals(e.getInstanceLocation()));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
   public void testAddsSchema() {
     final SchemaRepository repository = SchemaRepository
       .create(


### PR DESCRIPTION
Fixes #153

### Motivation

The `contains` validation loop iterates with its own variable `j` but built the sub-error instance location from the enclosing scope's `i` — the index where `prefixItems`/`items` processing stopped, which is `0` when those keywords are absent. Every failing element was therefore reported at the same wrong location: validating `[1, 2]` against `{"contains": {"type": "string"}, "minContains": 1}` reported both per-item type errors at `#/0`.

### Changes

Build the location from `j`. Added a regression test asserting each failing item is reported at its own location (`#/0` and `#/1`).

Note: #152 touches the neighboring lines of the same loop (behavior-preserving hoist); whichever merges second will have a trivial conflict — happy to rebase either.
