### PR TITLE
Fix wording of the Validate documentation section

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -95,9 +95,8 @@ sub-schemas should be provided to a repository object.
 Given the dynamic nature of json-schema and the conditional `if-then-else` it is not possible to validate in a streaming
 scenario. Validation is for this reason a blocking operation. If you are aware that validation will be a very expensive
 process, then it is advisable to run the validation on a dedicated thread pool or using `executeBlocking`.
-A schema could have two states:
 
-To validate a schema:
+To validate an object against a schema:
 
 [source,$lang]
 ----


### PR DESCRIPTION
Fixes #68

The Validate section of the asciidoc said "To validate a schema:" although the linked example validates an object against a schema, and carried a dangling "A schema could have two states:" sentence — a leftover from the removed two-state schema API. Reworded the former and removed the latter.