### PR TITLE
Fix incorrect messages and keywordLocation in validation errors

### DIFF
--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -448,7 +448,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         }
 
         if (schema.containsKey("maxProperties") && Numbers.gt(keys.size(), schema.get("maxProperties"))) {
-          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxProperties"), baseLocation + "/maxProperties", "Instance does not have at least " + schema.get("maxProperties") + " properties", OutputErrorType.INVALID_VALUE));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxProperties"), baseLocation + "/maxProperties", "Instance has more than " + schema.get("maxProperties") + " properties", OutputErrorType.INVALID_VALUE));
         }
 
         if (schema.containsKey("propertyNames")) {
@@ -667,11 +667,11 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       }
       case "array": {
         if (schema.containsKey("maxItems") && Numbers.gt(((JsonArray) instance).size(), schema.get("maxItems"))) {
-          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxItems"), baseLocation + "/maxItems", "Array has too many items ( + " + ((JsonArray) instance).size() + " > " + schema.get("maxItems") + ")", OutputErrorType.INVALID_VALUE));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxItems"), baseLocation + "/maxItems", "Array has too many items (" + ((JsonArray) instance).size() + " > " + schema.get("maxItems") + ")", OutputErrorType.INVALID_VALUE));
         }
 
         if (schema.containsKey("minItems") && Numbers.lt(((JsonArray) instance).size(), schema.get("minItems"))) {
-          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minItems"), baseLocation + "/minItems", "Array has too few items ( + " + ((JsonArray) instance).size() + " < " + schema.get("minItems") + ")", OutputErrorType.MISSING_VALUE));
+          errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minItems"), baseLocation + "/minItems", "Array has too few items (" + ((JsonArray) instance).size() + " < " + schema.get("minItems") + ")", OutputErrorType.MISSING_VALUE));
         }
 
         final int length = ((JsonArray) instance).size();
@@ -773,7 +773,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
               evaluated.add(i);
               if (!result.getValid()) {
                 stop = outputFormat == OutputFormat.Flag;
-                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/additionalItems"), schemaLocation + "/additionalItems", "Items did not match additional items schema", result.getErrorType()));
+                errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/additionalItems"), baseLocation + "/additionalItems", "Items did not match additional items schema", result.getErrorType()));
                 if (result.getErrors() != null) {
                   errors.addAll(result.getErrors());
                 }
@@ -824,7 +824,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             } else if (schema.containsKey("minContains") && Numbers.lt(contained, schema.get("minContains"))) {
               errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/minContains"), baseLocation + "/minContains", "Array must contain at least " + schema.get("minContains") + " items matching schema. Only " + contained + " items were found", OutputErrorType.MISSING_VALUE));
             } else if (schema.containsKey("maxContains") && Numbers.gt(contained, schema.get("maxContains"))) {
-              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxContains"), baseLocation + "/maxContains", "Array may contain at most " + schema.get("minContains") + " items matching schema. " + contained + " items were found", OutputErrorType.INVALID_VALUE));
+              errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/maxContains"), baseLocation + "/maxContains", "Array may contain at most " + schema.get("maxContains") + " items matching schema. " + contained + " items were found", OutputErrorType.INVALID_VALUE));
             }
           }
         }

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -405,7 +405,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
             dynamicContext
           );
           if (!thenResult.getValid()) {
-            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/if"), baseLocation + "/if", "Instance does not match \"then\" schema", thenResult.getErrorType()));
+            errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/then"), baseLocation + "/then", "Instance does not match \"then\" schema", thenResult.getErrorType()));
             if (thenResult.getErrors() != null) {
               errors.addAll(thenResult.getErrors());
             }

--- a/src/test/java/io/vertx/tests/ValidatorTest.java
+++ b/src/test/java/io/vertx/tests/ValidatorTest.java
@@ -179,6 +179,26 @@ public class ValidatorTest {
 
   @Test
   @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testThenErrorKeywordLocation() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject()
+        .put("if", new JsonObject().put("type", "string"))
+        .put("then", new JsonObject().put("minLength", 5))),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012)
+        .setOutputFormat(Basic));
+
+    final OutputUnit res = validator.validate("abc");
+
+    assertThat(res.getValid()).isFalse();
+    // a failing "then" schema is reported at /then, like a failing "else" is at /else
+    assertThat(res.getErrors())
+      .anyMatch(e -> "#/then".equals(e.getKeywordLocation()) && e.getError().contains("\"then\""));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
   public void testAddsSchema() {
     final SchemaRepository repository = SchemaRepository
       .create(

--- a/src/test/java/io/vertx/tests/ValidatorTest.java
+++ b/src/test/java/io/vertx/tests/ValidatorTest.java
@@ -95,6 +95,90 @@ public class ValidatorTest {
 
   @Test
   @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testMaxPropertiesErrorMessage() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject().put("type", "object").put("maxProperties", 1)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012)
+        .setOutputFormat(Basic));
+
+    final OutputUnit res = validator.validate(new JsonObject().put("a", 1).put("b", 2));
+
+    assertThat(res.getValid()).isFalse();
+    assertThat(res.getErrors())
+      .anyMatch(e -> e.getError().contains("has more than 1 properties"));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testItemsBoundsErrorMessages() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject().put("type", "array").put("minItems", 1).put("maxItems", 2)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012)
+        .setOutputFormat(Basic));
+
+    final OutputUnit tooMany = validator.validate(new JsonArray().add(1).add(2).add(3));
+    assertThat(tooMany.getValid()).isFalse();
+    assertThat(tooMany.getErrors())
+      .anyMatch(e -> e.getError().contains("Array has too many items (3 > 2)"));
+
+    final OutputUnit tooFew = validator.validate(new JsonArray());
+    assertThat(tooFew.getValid()).isFalse();
+    assertThat(tooFew.getErrors())
+      .anyMatch(e -> e.getError().contains("Array has too few items (0 < 1)"));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testMaxContainsErrorMessage() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject()
+        .put("type", "array")
+        .put("contains", new JsonObject().put("type", "string"))
+        .put("minContains", 1)
+        .put("maxContains", 2)),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT202012)
+        .setOutputFormat(Basic));
+
+    final OutputUnit res = validator.validate(new JsonArray().add("a").add("b").add("c"));
+
+    assertThat(res.getValid()).isFalse();
+    // the message must reference the maxContains value, not minContains
+    assertThat(res.getErrors())
+      .anyMatch(e -> e.getError().contains("at most 2 items"));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testAdditionalItemsErrorKeywordLocation() {
+    final Validator validator = Validator.create(
+      JsonSchema.of(new JsonObject()
+        .put("definitions", new JsonObject()
+          .put("tuple", new JsonObject()
+            .put("type", "array")
+            .put("items", new JsonArray().add(new JsonObject().put("type", "string")))
+            .put("additionalItems", new JsonObject().put("type", "string"))))
+        .put("$ref", "#/definitions/tuple")),
+      new JsonSchemaOptions()
+        .setBaseUri("https://vertx.io")
+        .setDraft(Draft.DRAFT7)
+        .setOutputFormat(Basic));
+
+    final OutputUnit res = validator.validate(new JsonArray().add("a").add(2));
+
+    assertThat(res.getValid()).isFalse();
+    // the keyword location is the dynamic path through $ref, like every other error
+    assertThat(res.getErrors())
+      .anyMatch(e -> "#/$ref/additionalItems".equals(e.getKeywordLocation()));
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
   public void testAddsSchema() {
     final SchemaRepository repository = SchemaRepository
       .create(


### PR DESCRIPTION
Fixes #156

Follow-up to #153, same family of defects in `SchemaValidatorImpl` error reporting — diagnostics only, validation verdicts are unaffected:

- the `maxProperties` error reused the `minProperties` message (*"Instance does not have at least 1 properties"* when exceeding the maximum);
- the `maxItems`/`minItems` messages contained a stray `( + ` literal (*"Array has too many items ( + 3 > 2)"*);
- the `maxContains` message interpolated the `minContains` value;
- the `additionalItems` summary error built its `keywordLocation` from `schemaLocation` instead of `baseLocation`, reporting e.g. `#/definitions/tuple/additionalItems` instead of the dynamic path `#/$ref/additionalItems`.

Added one regression test per defect; each failed on master before the fix. Full suite green.