### PR TITLE
Add formatValidation option, default to spec behavior per draft

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -110,6 +110,13 @@ If a validation fails, you can retrieve the `OutputErrorType` to help determine 
 - INVALID_VALUE, This is used when a value is provided, but the value does not match the given schema.
 - MISSING_VALUE, This is used when a value is not present, or not enough of the value is present but the schema requires it.
 
+== Format validation
+
+By default the `format` keyword follows the specification of the draft in use: it is validated as an assertion up to
+draft-7 and treated as an annotation only from draft 2019-09 on. Use
+{@link io.vertx.json.schema.JsonSchemaOptions#setFormatValidation} to override this behavior: `true` always validates
+formats, `false` never does.
+
 == Defining a custom JSON format
 
 By default, the schema validator will perform an NOOP on unknown formats, so they will be treated as valid inputs.

--- a/src/main/generated/io/vertx/json/schema/JsonSchemaOptionsConverter.java
+++ b/src/main/generated/io/vertx/json/schema/JsonSchemaOptionsConverter.java
@@ -27,6 +27,11 @@ public class JsonSchemaOptionsConverter {
             obj.setOutputFormat(io.vertx.json.schema.OutputFormat.valueOf((String)member.getValue()));
           }
           break;
+        case "formatValidation":
+          if (member.getValue() instanceof Boolean) {
+            obj.setFormatValidation((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -44,6 +49,9 @@ public class JsonSchemaOptionsConverter {
     }
     if (obj.getOutputFormat() != null) {
       json.put("outputFormat", obj.getOutputFormat().name());
+    }
+    if (obj.getFormatValidation() != null) {
+      json.put("formatValidation", obj.getFormatValidation());
     }
   }
 }

--- a/src/main/java/io/vertx/json/schema/JsonSchemaOptions.java
+++ b/src/main/java/io/vertx/json/schema/JsonSchemaOptions.java
@@ -40,6 +40,12 @@ public class JsonSchemaOptions {
    */
   private OutputFormat outputFormat = OutputFormat.Flag;
 
+  /**
+   * Whether the {@code format} keyword is validated as an assertion. When {@code null} the behavior follows the
+   * draft in use: formats are asserted up to draft-7 and are annotations only from draft 2019-09 on.
+   */
+  private Boolean formatValidation;
+
   public JsonSchemaOptions() {
   }
 
@@ -52,6 +58,7 @@ public class JsonSchemaOptions {
     this.baseUri = other.baseUri;
     this.draft = other.draft;
     this.outputFormat = other.outputFormat;
+    this.formatValidation = other.formatValidation;
   }
 
   public String getBaseUri() {
@@ -78,6 +85,24 @@ public class JsonSchemaOptions {
 
   public JsonSchemaOptions setOutputFormat(OutputFormat outputFormat) {
     this.outputFormat = outputFormat;
+    return this;
+  }
+
+  public Boolean getFormatValidation() {
+    return formatValidation;
+  }
+
+  /**
+   * Controls whether the {@code format} keyword is validated as an assertion. When not set, the behavior follows
+   * the draft in use: formats are asserted up to draft-7 and are annotations only from draft 2019-09 on, as
+   * required by the specification. Set to {@code true} to always assert formats or {@code false} to never assert
+   * them.
+   *
+   * @param formatValidation {@code true} to always assert formats, {@code false} to never assert them
+   * @return fluent self reference
+   */
+  public JsonSchemaOptions setFormatValidation(Boolean formatValidation) {
+    this.formatValidation = formatValidation;
     return this;
   }
 

--- a/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
+++ b/src/main/java/io/vertx/json/schema/impl/SchemaValidatorImpl.java
@@ -20,6 +20,7 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
   private final Draft draft;
   private final OutputFormat outputFormat;
   private final JsonFormatValidator formatValidator;
+  private final boolean assertFormat;
 
   public SchemaValidatorImpl(JsonSchema schema, JsonSchemaOptions options, Map<String, JsonSchema> lookup,
                              boolean dereference, JsonFormatValidator formatValidator) {
@@ -36,6 +37,10 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
       Draft.fromIdentifier(schema.get("$schema")) :
       options.getDraft();
     this.outputFormat = options.getOutputFormat();
+    // by default the format keyword is an assertion up to draft-7 and an annotation from draft 2019-09 on
+    this.assertFormat = options.getFormatValidation() != null ?
+      options.getFormatValidation() :
+      draft == null || !draft.isAfter(Draft.DRAFT7);
     this.lookup = new HashMap<>(lookup);
     if (dereference) {
       URL baseUri = new URL(options.getBaseUri());
@@ -928,7 +933,8 @@ public class SchemaValidatorImpl implements SchemaValidatorInternal {
         if (schema.containsKey("pattern") && !Pattern.compile(schema.get("pattern")).matcher((String) instance).find()) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/pattern"), baseLocation + "/pattern", "String does not match pattern", OutputErrorType.INVALID_VALUE));
         }
-        if (schema.containsKey("format") &&
+        if (assertFormat &&
+            schema.containsKey("format") &&
             !Format.fastFormat(schema.get("format"), (String) instance)) {
           errors.add(new OutputUnit(instanceLocation, computeAbsoluteKeywordLocation(schema, schemaLocation + "/format"), baseLocation + "/format", "String does not match format \"" + schema.get("format") + "\"", OutputErrorType.INVALID_VALUE));
         }

--- a/src/test/java/io/vertx/tests/FormatValidationTest.java
+++ b/src/test/java/io/vertx/tests/FormatValidationTest.java
@@ -1,0 +1,62 @@
+package io.vertx.tests;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.json.schema.Draft;
+import io.vertx.json.schema.JsonSchema;
+import io.vertx.json.schema.JsonSchemaOptions;
+import io.vertx.json.schema.Validator;
+import io.vertx.junit5.Timeout;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormatValidationTest {
+
+  private static final JsonObject DATE_SCHEMA = new JsonObject()
+    .put("type", "string")
+    .put("format", "date");
+
+  private static Validator validator(Draft draft, Boolean formatValidation) {
+    JsonSchemaOptions options = new JsonSchemaOptions()
+      .setBaseUri("https://vertx.io")
+      .setDraft(draft);
+    if (formatValidation != null) {
+      options.setFormatValidation(formatValidation);
+    }
+    return Validator.create(JsonSchema.of(DATE_SCHEMA.copy()), options);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testFormatIsAnnotationOnlyByDefaultSince201909() {
+    // https://json-schema.org/draft/2020-12: format is an annotation by default
+    assertThat(validator(Draft.DRAFT201909, null).validate("not-a-date").getValid()).isEqualTo(true);
+    assertThat(validator(Draft.DRAFT202012, null).validate("not-a-date").getValid()).isEqualTo(true);
+    // valid values are unaffected
+    assertThat(validator(Draft.DRAFT202012, null).validate("2026-08-11").getValid()).isEqualTo(true);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testFormatIsAssertedByDefaultUpToDraft7() {
+    assertThat(validator(Draft.DRAFT4, null).validate("not-a-date").getValid()).isEqualTo(false);
+    assertThat(validator(Draft.DRAFT7, null).validate("not-a-date").getValid()).isEqualTo(false);
+    assertThat(validator(Draft.DRAFT7, null).validate("2026-08-11").getValid()).isEqualTo(true);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testFormatValidationCanBeForcedOn() {
+    assertThat(validator(Draft.DRAFT202012, true).validate("not-a-date").getValid()).isEqualTo(false);
+    assertThat(validator(Draft.DRAFT202012, true).validate("2026-08-11").getValid()).isEqualTo(true);
+  }
+
+  @Test
+  @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+  public void testFormatValidationCanBeForcedOff() {
+    assertThat(validator(Draft.DRAFT7, false).validate("not-a-date").getValid()).isEqualTo(true);
+    assertThat(validator(Draft.DRAFT4, false).validate("not-a-date").getValid()).isEqualTo(true);
+  }
+}

--- a/src/test/java/io/vertx/tests/TCKTest.java
+++ b/src/test/java/io/vertx/tests/TCKTest.java
@@ -150,12 +150,14 @@ public class TCKTest {
       assertThat(testSchema).isNotNull();
 
       // setup the initial validator object
-      final Validator validator = repository.validator(
-        testSchema,
-        new JsonSchemaOptions()
-          .setDraft(draft)
-          .setBaseUri("https://github.com/eclipse-vertx"),
-        true);
+      final JsonSchemaOptions options = new JsonSchemaOptions()
+        .setDraft(draft)
+        .setBaseUri("https://github.com/eclipse-vertx");
+      // the optional format suites assume the format-assertion behavior is enabled
+      if (suiteName.contains("/optional/format")) {
+        options.setFormatValidation(true);
+      }
+      final Validator validator = repository.validator(testSchema, options, true);
 
       OutputUnit result =
         validator

--- a/src/test/java/io/vertx/tests/impl/SchemaValidatorImplTest.java
+++ b/src/test/java/io/vertx/tests/impl/SchemaValidatorImplTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SchemaValidatorImplTest {
   private static final JsonSchemaOptions DUMMY_OPTIONS =
-    new JsonSchemaOptions().setBaseUri("app://").setDraft(DRAFT201909);
+    new JsonSchemaOptions().setBaseUri("app://").setDraft(DRAFT201909).setFormatValidation(true);
 
   static Stream<Arguments> testStringSchema() {
     return Stream.of(

--- a/src/test/resources/unsupported-tck-tests.properties
+++ b/src/test/resources/unsupported-tck-tests.properties
@@ -1,22 +1,5 @@
 #Unsupported json-schema.org TCK tests (suiteName/suiteDescription/testDescription)
 #Wed Apr 20 09:21:54 CEST 2022
-draft2019-09/format/date\ format/invalid\ date\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/date-time\ format/invalid\ date-time\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/duration\ format/invalid\ duration\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/email\ format/invalid\ email\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/hostname\ format/invalid\ hostname\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/ipv4\ format/invalid\ ipv4\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/ipv6\ format/invalid\ ipv6\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/json-pointer\ format/invalid\ json-pointer\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/regex\ format/invalid\ regex\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/relative-json-pointer\ format/invalid\ relative-json-pointer\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/time\ format/invalid\ time\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/uri\ format/invalid\ uri\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/uri-reference\ format/invalid\ uri-reference\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/uri-template\ format/invalid\ uri-template\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/uuid\ format/invalid\ uuid\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/idn-hostname\ format/invalid\ idn-hostname\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2019-09/format/idn-email\ format/invalid\ idn-email\ string\ is\ only\ an\ annotation\ by\ default=skip
 draft2019-09/optional/ecmascript-regex/ECMA\ 262\ regex\ escapes\ control\ codes\ with\ \\c\ and\ lower\ letter/matches=skip
 draft2019-09/optional/ecmascript-regex/ECMA\ 262\ \\S\ matches\ everything\ but\ whitespace/EM\ SPACE\ does\ not\ match\ (Space_Separator)=skip
 draft2019-09/optional/ecmascript-regex/ECMA\ 262\ \\S\ matches\ everything\ but\ whitespace/latin-1\ non-breaking-space\ does\ not\ match=skip
@@ -53,23 +36,6 @@ draft2020-12/dynamicRef/A\ $dynamicRef\ to\ an\ $anchor\ in\ the\ same\ schema\ 
 draft2020-12/dynamicRef/A\ $dynamicRef\ with\ intermediate\ scopes\ that\ don't\ include\ a\ matching\ $dynamicAnchor\ should\ not\ affect\ dynamic\ scope\ resolution/An\ array\ containing\ non-strings\ is\ invalid=skip
 draft2020-12/dynamicRef/after\ leaving\ a\ dynamic\ scope,\ it\ should\ not\ be\ used\ by\ a\ $dynamicRef/first_scope\ is\ not\ in\ dynamic\ scope\ for\ the\ $dynamicRef=skip
 draft2020-12/dynamicRef/after\ leaving\ a\ dynamic\ scope,\ it\ should\ not\ be\ used\ by\ a\ $dynamicRef/string\ matches\ /$defs/thingy,\ but\ the\ $dynamicRef\ does\ not\ stop\ here=skip
-draft2020-12/format/date\ format/invalid\ date\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/date-time\ format/invalid\ date-time\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/duration\ format/invalid\ duration\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/email\ format/invalid\ email\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/hostname\ format/invalid\ hostname\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/ipv4\ format/invalid\ ipv4\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/ipv6\ format/invalid\ ipv6\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/json-pointer\ format/invalid\ json-pointer\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/regex\ format/invalid\ regex\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/relative-json-pointer\ format/invalid\ relative-json-pointer\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/time\ format/invalid\ time\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/uri\ format/invalid\ uri\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/uri-reference\ format/invalid\ uri-reference\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/uri-template\ format/invalid\ uri-template\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/uuid\ format/invalid\ uuid\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/idn-hostname\ format/invalid\ idn-hostname\ string\ is\ only\ an\ annotation\ by\ default=skip
-draft2020-12/format/idn-email\ format/invalid\ idn-email\ string\ is\ only\ an\ annotation\ by\ default=skip
 draft2020-12/optional/ecmascript-regex/ECMA\ 262\ regex\ escapes\ control\ codes\ with\ \\c\ and\ lower\ letter/matches=skip
 draft2020-12/optional/ecmascript-regex/ECMA\ 262\ \\S\ matches\ everything\ but\ whitespace/EM\ SPACE\ does\ not\ match\ (Space_Separator)=skip
 draft2020-12/optional/ecmascript-regex/ECMA\ 262\ \\S\ matches\ everything\ but\ whitespace/latin-1\ non-breaking-space\ does\ not\ match=skip


### PR DESCRIPTION
Fixes #160

### Motivation

Since draft 2019-09 the specification defines `format` as an **annotation by default**; the validator asserts it unconditionally for every draft. This is stricter than the spec and keeps 34 default-behavior format tests from the official suite permanently skipped.

### Changes

- New `JsonSchemaOptions.setFormatValidation(Boolean)`:
  - unset (default): draft-dependent — asserted up to draft-7 (unchanged), annotation-only from 2019-09 on (spec default);
  - `true`: always assert; `false`: never assert.
- `SchemaValidatorImpl` resolves the effective behavior once in its constructor (after draft resolution, since the draft may come from `$schema`) and gates the built-in `Format.fastFormat` check. The pluggable `JsonFormatValidator` is unaffected — supplying one is already an explicit opt-in.
- The 34 `"invalid X string is only an annotation by default"` entries for 2019-09/2020-12 are removed from `unsupported-tck-tests.properties` and now pass. The `optional/format` suites run with `formatValidation(true)`, per the test-suite guidance that they assume the format-assertion behavior.
- Documented in the asciidoc; new `FormatValidationTest` covers all drafts × default/forced-on/forced-off.

### ⚠️ Behavior change

2019-09/2020-12 schemas that relied on format errors need `setFormatValidation(true)` to restore the previous behavior (draft-4/7 are unchanged). Happy to flip the default to `true` (pure opt-in, no behavior change, but the 34 TCK tests stay skipped) if you prefer backward compatibility over spec compliance — say the word and I'll adjust.

Full suite: 4801 tests, 0 failures, skips down from 152 to 118.
